### PR TITLE
Keep chart state in single model view

### DIFF
--- a/libs/fairness/src/lib/v2/Controls/OverallTable.tsx
+++ b/libs/fairness/src/lib/v2/Controls/OverallTable.tsx
@@ -17,7 +17,6 @@ export interface IOverallTableProps {
   formattedBinValues: Array<string[] | undefined>;
   binLabels: string[];
   metricLabels: string[];
-  expandAttributes: boolean;
   overallMetrics: string[];
   binGroup: string;
 }

--- a/libs/fairness/src/lib/v2/Controls/ReportChart.tsx
+++ b/libs/fairness/src/lib/v2/Controls/ReportChart.tsx
@@ -141,7 +141,7 @@ export class ReportChart extends React.Component<IReportChartProps, IState> {
       return;
     }
     if (option.key !== this.state.chartKey) {
-      let newChartKey = option.key.toString();
+      const newChartKey = option.key.toString();
       this.props.onUpdateChartKey(newChartKey);
       this.setState({ chartKey: newChartKey });
     }

--- a/libs/fairness/src/lib/v2/Controls/ReportChart.tsx
+++ b/libs/fairness/src/lib/v2/Controls/ReportChart.tsx
@@ -24,19 +24,26 @@ export interface IReportChartProps {
   featureBinPickerProps: IFeatureBinPickerPropsV2;
   areaHeights: number;
   metrics: IMetrics;
+  chartKey?: string;
+  onUpdateChartKey: (chartKey: string) => void;
 }
 
 const performanceKey = "performance";
 const outcomeKey = "outcome";
 
 export interface IState {
-  displayPlotKey: string;
+  chartKey: string;
 }
 
 export class ReportChart extends React.Component<IReportChartProps, IState> {
   public constructor(props: IReportChartProps) {
     super(props);
-    this.state = { displayPlotKey: outcomeKey };
+    if (this.props.chartKey) {
+      this.state = { chartKey: this.props.chartKey };
+    } else {
+      this.state = { chartKey: outcomeKey };
+    }
+    this.props.onUpdateChartKey(this.state.chartKey);
   }
 
   public render(): React.ReactNode {
@@ -100,12 +107,12 @@ export class ReportChart extends React.Component<IReportChartProps, IState> {
           id="chartSelectionDropdown"
           styles={{ dropdown: { maxWidth: "75%" } }}
           label={localization.Fairness.Report.chartChoiceDropdownHeader}
-          defaultSelectedKey={this.state.displayPlotKey}
+          defaultSelectedKey={this.state.chartKey}
           options={displayOptions}
           disabled={false}
           onChange={this.onChange.bind(this)}
         />
-        {this.state.displayPlotKey === performanceKey && (
+        {this.state.chartKey === performanceKey && (
           <PerformancePlot
             dashboardContext={this.props.dashboardContext}
             metrics={this.props.metrics}
@@ -114,7 +121,7 @@ export class ReportChart extends React.Component<IReportChartProps, IState> {
             areaHeights={this.props.areaHeights}
           />
         )}
-        {this.state.displayPlotKey === outcomeKey && (
+        {this.state.chartKey === outcomeKey && (
           <OutcomePlot
             dashboardContext={this.props.dashboardContext}
             metrics={this.props.metrics}
@@ -133,8 +140,10 @@ export class ReportChart extends React.Component<IReportChartProps, IState> {
     if (!option) {
       return;
     }
-    if (option.key !== this.state.displayPlotKey) {
-      this.setState({ displayPlotKey: option.key.toString() });
+    if (option.key !== this.state.chartKey) {
+      let newChartKey = option.key.toString();
+      this.props.onUpdateChartKey(newChartKey);
+      this.setState({ chartKey: newChartKey });
     }
   }
 }

--- a/libs/fairness/src/lib/v2/WizardReport.tsx
+++ b/libs/fairness/src/lib/v2/WizardReport.tsx
@@ -32,7 +32,7 @@ export interface IState {
   fairnessKey?: string;
   performanceKey?: string;
   showModalHelp?: boolean;
-  expandAttributes: boolean;
+  chartKey?: string;
 }
 
 export interface IReportProps extends IModelComparisonProps {
@@ -198,7 +198,6 @@ export class WizardReport extends React.PureComponent<IReportProps, IState> {
                 formattedBinValues={formattedBinValues}
                 metricLabels={metricLabels}
                 overallMetrics={overallMetrics}
-                expandAttributes={this.state.expandAttributes}
                 binValues={this.state.metrics.performance.bins}
               />
               <ReportChart
@@ -208,6 +207,8 @@ export class WizardReport extends React.PureComponent<IReportProps, IState> {
                 metrics={this.state.metrics}
                 fairnessPickerProps={this.props.fairnessPickerProps}
                 performancePickerProps={this.props.performancePickerProps}
+                chartKey={this.state.chartKey}
+                onUpdateChartKey={this.updateChartKey}
               />
             </Stack>
           </Stack.Item>
@@ -280,6 +281,10 @@ export class WizardReport extends React.PureComponent<IReportProps, IState> {
   //   }
   //   this.props.onEditConfigs();
   // };
+
+  private readonly updateChartKey = (chartKey: string): void => {
+    this.setState({ chartKey });
+  };
 
   private readonly featureChanged = (
     _: React.FormEvent<HTMLDivElement>,


### PR DESCRIPTION
This came up in a recent bug bash. The single model view charts always reset to the default (`outcomePlot`) rather than keeping state. This is undesirable if all you care about is the `performancePlot`, so this change adds state to keep track of the selection.

Additionally, this PR removes the `expandAttributes` property that wasn't used anymore, and renames `displayPlotKey` for consistency.