### PR TITLE
fix error cohort stats in big data case

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/CohortStats.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/CohortStats.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export class CohortStats {
+  public totalAll = 0;
+  public totalCohort = 0;
+  public totalCorrect = 0;
+  public totalCohortCorrect = 0;
+  public totalIncorrect = 0;
+  public totalCohortIncorrect = 0;
+  public errorRate = 0;
+  public errorCoverage = 0;
+  public constructor(
+    numError: number,
+    totalCount: number,
+    baseNumError: number,
+    baseTotalCount: number,
+    errorRate: number
+  ) {
+    this.totalCohortCorrect = totalCount - numError;
+    this.totalCohortIncorrect = numError;
+    this.totalCohort = totalCount;
+    this.errorCoverage = (this.totalCohortIncorrect / baseNumError) * 100;
+    this.errorRate = errorRate;
+    this.totalAll = baseTotalCount;
+    this.totalCorrect = baseTotalCount - baseNumError;
+    this.totalIncorrect = baseNumError;
+  }
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/EditCohort/EditCohort.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/EditCohort/EditCohort.tsx
@@ -142,7 +142,11 @@ export class EditCohort extends React.Component<
         cohort.cohort.filters,
         cohort.cohort.compositeFilters
       ),
-      this.props.jointDataset
+      this.props.jointDataset,
+      cohort.cells,
+      cohort.source,
+      cohort.isTemporary,
+      cohort.cohortStats
     );
     this.props.onSave(cohort, savedCohort);
   }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/ErrorAnalysisView/ErrorAnalysisView.tsx
@@ -5,6 +5,7 @@ import { ICompositeFilter, IFilter } from "@responsible-ai/interpret";
 import { ITheme } from "office-ui-fabric-react";
 import React from "react";
 
+import { CohortStats } from "../../CohortStats";
 import { ErrorAnalysisOptions } from "../../ErrorAnalysisDashboard";
 import { ErrorCohort, ErrorDetectorCohortSource } from "../../ErrorCohort";
 import { HelpMessageDict } from "../../Interfaces/IStringsParam";
@@ -25,7 +26,8 @@ export interface IErrorAnalysisViewProps {
     filters: IFilter[],
     compositeFilters: ICompositeFilter[],
     source: ErrorDetectorCohortSource,
-    cells: number
+    cells: number,
+    cohortStats: CohortStats | undefined
   ) => void;
   selectedCohort: ErrorCohort;
   baseCohort: ErrorCohort;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
@@ -12,6 +12,7 @@ import {
 } from "office-ui-fabric-react";
 import React from "react";
 
+import { CohortStats } from "../../CohortStats";
 import { noFeature } from "../../Constants";
 import { ErrorCohort, ErrorDetectorCohortSource } from "../../ErrorCohort";
 import { IMatrixAreaState, IMatrixFilterState } from "../../MatrixFilterState";
@@ -28,7 +29,8 @@ export interface IMatrixFilterProps {
     filters: IFilter[],
     compositeFilters: ICompositeFilter[],
     source: ErrorDetectorCohortSource,
-    cells: number
+    cells: number,
+    cohortStats: CohortStats | undefined
   ) => void;
   selectedCohort: ErrorCohort;
   baseCohort: ErrorCohort;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixLegend/MatrixLegend.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixLegend/MatrixLegend.tsx
@@ -53,7 +53,9 @@ export class MatrixLegend extends React.Component<IMatrixLegendProps> {
               <Stack tokens={cellTokens}>
                 <div className={classNames.smallHeader}>Cells</div>
                 <div className={classNames.valueBlack}>
-                  {this.props.selectedCohort.cells}
+                  {this.props.selectedCohort.cells === 0
+                    ? "-"
+                    : this.props.selectedCohort.cells}
                 </div>
               </Stack>
             </Stack>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/SaveCohort/SaveCohort.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/SaveCohort/SaveCohort.tsx
@@ -123,7 +123,11 @@ export class SaveCohort extends React.Component<
         tempCohort.cohort.filters,
         tempCohort.cohort.compositeFilters
       ),
-      this.props.jointDataset
+      this.props.jointDataset,
+      tempCohort.cells,
+      tempCohort.source,
+      false,
+      tempCohort.cohortStats
     );
     this.props.onSave(savedCohort);
   }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -37,6 +37,7 @@ import {
 } from "office-ui-fabric-react";
 import React from "react";
 
+import { CohortStats } from "./CohortStats";
 import { CohortInfo } from "./Controls/CohortInfo/CohortInfo";
 import { CohortList } from "./Controls/CohortList/CohortList";
 import { EditCohort } from "./Controls/EditCohort/EditCohort";
@@ -417,7 +418,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       trueY: props.trueY
     });
     const globalProps = ErrorAnalysisDashboard.buildGlobalProperties(props);
-    // consider taking filters in as param arg for programatic users
+    // consider taking filters in as param arg for programmatic users
     const cohorts = [
       new ErrorCohort(
         new Cohort(
@@ -627,7 +628,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                 selectedCohort
               });
             }}
-            cohorts={this.state.cohorts}
+            cohorts={this.state.cohorts.filter((cohort) => !cohort.isTemporary)}
           />
         )}
         <div>
@@ -824,7 +825,8 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
     filters: IFilter[],
     compositeFilters: ICompositeFilter[],
     source: ErrorDetectorCohortSource = ErrorDetectorCohortSource.None,
-    cells = 0
+    cells: number,
+    cohortStats: CohortStats | undefined
   ): void {
     // Need to relabel the filter names based on index in joint dataset
     const filtersRelabeled = ErrorCohort.getDataFilters(
@@ -856,7 +858,8 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       this.state.jointDataset,
       cells,
       source,
-      addTemporaryCohort
+      addTemporaryCohort,
+      cohortStats
     );
     let cohorts = this.state.cohorts.filter(
       (errorCohort) => !errorCohort.isTemporary

--- a/notebooks/fairness-interpretability-dashboard-loan-allocation.ipynb
+++ b/notebooks/fairness-interpretability-dashboard-loan-allocation.ipynb
@@ -225,6 +225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "### Note we downsample the test data since visualization dashboard can't handle the full dataset\n",
     "global_explanation = explainer.explain_global(X_test[:1000])"
    ]
   },


### PR DESCRIPTION
fix error cohort stats in big data case
- when we have large data (like categorical notebook example), we should use the info from python backend for the legends instead of the downsampled explanation data