### PR TITLE
tree view adjustments and fix for indexing issue

### DIFF
--- a/libs/core-ui/src/lib/Cohort/Cohort.ts
+++ b/libs/core-ui/src/lib/Cohort/Cohort.ts
@@ -196,15 +196,20 @@ export class Cohort {
     if (!filteredData) {
       return [];
     }
-    if (this.filters.length > 0) {
+    const hasFilters = this.filters.length > 0;
+    const hasCompositeFilters = this.compositeFilters.length > 0;
+    if (hasFilters) {
       filteredData = filteredData.filter((row) =>
         this.filterRow(row, this.filters)
       );
     }
-    if (this.compositeFilters.length > 0) {
+    if (hasCompositeFilters) {
       filteredData = filteredData.filter((row) =>
         this.filterComposite(row, this.compositeFilters, Operations.And)
       );
+    }
+    if (!hasFilters && !hasCompositeFilters) {
+      filteredData = [...filteredData];
     }
     return filteredData;
   }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
@@ -27,6 +27,7 @@ export interface ITreeViewRendererStyles {
   errorRateGradientStyle: IStyle;
   linksTransitionGroup: IStyle;
   nodesTransitionGroup: IStyle;
+  tooltipTransitionGroup: IStyle;
   linkLabelsTransitionGroup: IStyle;
 }
 
@@ -108,7 +109,8 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
     },
     nodeText: {
       fill: "#555",
-      fontSize: "9px",
+      fontSize: "10px",
+      fontWeight: "bolder",
       pointerEvents: "none",
       transform: "translate(0px, 0px)"
     },
@@ -125,6 +127,9 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
       margin: "0",
       padding: "0",
       width: "100%"
+    },
+    tooltipTransitionGroup: {
+      transform: "translate(40px, 90px)"
     },
     treeDescription: {
       padding: "30px 0px 0px 35px"

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -387,7 +387,7 @@ export class TreeViewRenderer extends React.PureComponent<
                           textAnchor="middle"
                           className={classNames.nodeText}
                         >
-                          {node.data.error} / {node.data.size}
+                          {node.data.error}/{node.data.size}
                         </text>
                       </g>
                     </CSSTransition>
@@ -433,7 +433,7 @@ export class TreeViewRenderer extends React.PureComponent<
                 ))}
               </TransitionGroup>
               <g
-                className={classNames.nodesTransitionGroup}
+                className={classNames.tooltipTransitionGroup}
                 pointerEvents="none"
               >
                 {nodeData.map((node) => (

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Utils/DatasetUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Utils/DatasetUtils.ts
@@ -29,10 +29,10 @@ export function constructRows(
     const tableRow = [];
     tableRow.push(row[JointDataset.IndexLabel]);
     if (jointDataset.hasTrueY) {
-      tableRow.push(row[JointDataset.TrueYLabel]);
+      pushRowData(tableRow, JointDataset.TrueYLabel, jointDataset, row);
     }
     if (jointDataset.hasPredictedY) {
-      tableRow.push(row[JointDataset.PredictedYLabel]);
+      pushRowData(tableRow, JointDataset.PredictedYLabel, jointDataset, row);
     }
     tableRow.push(...data);
     rows.push(tableRow);
@@ -108,4 +108,18 @@ export function constructCols(
     index += 1;
   }
   return columns;
+}
+
+function pushRowData(
+  tableRow: any[],
+  property: string,
+  jointDataset: JointDataset,
+  row: { [key: string]: number }
+): void {
+  if (jointDataset.metaDict[property].isCategorical) {
+    const categories = jointDataset.metaDict[property].sortedCategoricalValues!;
+    tableRow.push(categories[row[property]]);
+  } else {
+    tableRow.push(row[property]);
+  }
 }


### PR DESCRIPTION
- minor adjustments to font and weight in tree view and fix for hover tooltip positioning (https://github.com/microsoft/responsible-ai-widgets/issues/228)
- fix showing categorical true y/predicted y values
- fix for indexing issue on all data cohort due to not making shallow copy (and data/aggregate views shuffle those rows, causing issues for local inspection view)