### PR TITLE
add color column to local explanation view

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InspectionView/InspectionView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InspectionView/InspectionView.tsx
@@ -20,6 +20,7 @@ import {
   IStackTokens,
   DetailsList,
   DetailsListLayoutMode,
+  mergeStyles,
   Selection,
   SelectionMode,
   Fabric,
@@ -101,12 +102,16 @@ export class InspectionView extends React.PureComponent<
       Math.min(numRows, 8),
       this.props.inspectedIndexes.length
     );
+    const colors = this.props.inspectedIndexes.map(
+      (_rowIndex, colorIndex) => FabricStyles.fabricColorPalette[colorIndex]
+    );
     this._rows = constructRows(
       cohortData,
       this.props.jointDataset,
       viewedRows,
       undefined,
-      this.props.inspectedIndexes
+      this.props.inspectedIndexes,
+      colors
     );
     const numCols: number = this.props.jointDataset.datasetFeatureCount;
     const featureNames: string[] = this.props.features;
@@ -116,7 +121,8 @@ export class InspectionView extends React.PureComponent<
       viewedCols,
       featureNames,
       this.props.jointDataset,
-      false
+      false,
+      true
     );
     this._selection = new Selection({
       onSelectionChanged: (): void => {
@@ -181,6 +187,7 @@ export class InspectionView extends React.PureComponent<
                     columns={this._columns}
                     setKey="set"
                     layoutMode={DetailsListLayoutMode.justified}
+                    onRenderItemColumn={this.renderItemColumn.bind(this)}
                     selectionPreservedOnEmptyClick={true}
                     ariaLabelForSelectionColumn="Toggle selection"
                     ariaLabelForSelectAllCheckbox="Toggle selection for all items"
@@ -220,6 +227,34 @@ export class InspectionView extends React.PureComponent<
         </Stack>
       </div>
     );
+  }
+
+  private renderItemColumn(
+    item: any,
+    index?: number,
+    column?: IColumn
+  ): React.ReactNode {
+    if (column && index !== undefined) {
+      const fieldContent = item[column.fieldName as keyof any] as string;
+
+      switch (column.key) {
+        case "color":
+          return (
+            <div
+              className={mergeStyles({
+                backgroundColor: fieldContent,
+                display: "block",
+                height: "100%",
+                width: "20px"
+              })}
+            ></div>
+          );
+
+        default:
+          return <span>{fieldContent}</span>;
+      }
+    }
+    return <span></span>;
   }
 
   private updateViewedFeatureImportances(

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Utils/DatasetUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Utils/DatasetUtils.ts
@@ -9,7 +9,8 @@ export function constructRows(
   jointDataset: JointDataset,
   viewedRows: number,
   filterFunction?: (row: { [key: string]: number }) => boolean,
-  indexes?: number[]
+  indexes?: number[],
+  colors?: string[]
 ): any[] {
   const rows = [];
   for (let i = 0; i < viewedRows; i++) {
@@ -28,6 +29,9 @@ export function constructRows(
     );
     const tableRow = [];
     tableRow.push(row[JointDataset.IndexLabel]);
+    if (colors) {
+      tableRow.push(colors[i]);
+    }
     if (jointDataset.hasTrueY) {
       pushRowData(tableRow, JointDataset.TrueYLabel, jointDataset, row);
     }
@@ -62,7 +66,8 @@ export function constructCols(
   viewedCols: number,
   featureNames: string[],
   jointDataset: JointDataset,
-  isCustomPointsView: boolean
+  isCustomPointsView: boolean,
+  hasColors = false
 ): IColumn[] {
   const columns: IColumn[] = [];
   columns.push({
@@ -74,6 +79,17 @@ export function constructCols(
     name: "Index"
   });
   let index = 1;
+  if (hasColors) {
+    columns.push({
+      fieldName: `${index}`,
+      isResizable: true,
+      key: `color`,
+      maxWidth: 100,
+      minWidth: 50,
+      name: "Color"
+    });
+    index++;
+  }
   if (!isCustomPointsView && jointDataset.hasTrueY) {
     columns.push({
       fieldName: `${index}`,


### PR DESCRIPTION
- add color column to local explanation view, resolves issues (https://github.com/microsoft/responsible-ai-widgets/issues/252, https://github.com/microsoft/responsible-ai-widgets/issues/198)
![image](https://user-images.githubusercontent.com/24683184/107697261-ffe8e980-6c80-11eb-9b32-1c719d55c5cd.png)
