### PR TITLE
improve node text color contrast on darker background

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ColorPalette.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ColorPalette.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { lab as Lab } from "d3-color";
+
 export enum ColorPalette {
   MinColor = "#F4D1D2",
   MaxColor = "#8d2323",
@@ -9,4 +11,9 @@ export enum ColorPalette {
   SelectedLineColor = "#089acc",
   UnselectedLineColor = "#e8eaed",
   LinkLabelOutline = "#089acc"
+}
+
+export function isColorDark(colorStr: string): boolean {
+  const val = Lab(colorStr).l;
+  return val <= 65;
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
@@ -9,7 +9,6 @@ import {
   JointDataset
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
-import { lab as Lab } from "d3-color";
 import { interpolateHcl as d3interpolateHcl } from "d3-interpolate";
 import { scaleLinear as d3scaleLinear } from "d3-scale";
 import {
@@ -29,7 +28,7 @@ import {
 import React from "react";
 
 import { CohortStats } from "../../CohortStats";
-import { ColorPalette } from "../../ColorPalette";
+import { ColorPalette, isColorDark } from "../../ColorPalette";
 import { noFeature } from "../../Constants";
 import { ErrorCohort, ErrorDetectorCohortSource } from "../../ErrorCohort";
 import { FilterProps } from "../../FilterProps";
@@ -658,11 +657,6 @@ export class MatrixArea extends React.PureComponent<
   }
 
   private textColorForBackground(colorStr: string): string {
-    return this.isColorDark(colorStr) ? "white" : "rgba(0,0,0,0.8)";
-  }
-
-  private isColorDark(colorStr: string): boolean {
-    const val = Lab(colorStr).l;
-    return val <= 65;
+    return isColorDark(colorStr) ? "white" : "rgba(0,0,0,0.8)";
   }
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
@@ -11,24 +11,25 @@ import {
 export interface ITreeViewRendererStyles {
   clickedNodeDashed: IStyle;
   clickedNodeFull: IStyle;
-  mainFrame: IStyle;
-  treeDescription: IStyle;
-  svgOuterFrame: IStyle;
-  innerFrame: IStyle;
-  node: IStyle;
-  nodeText: IStyle;
-  nopointer: IStyle;
-  linkLabel: IStyle;
   detailLines: IStyle;
   details: IStyle;
+  errorRateGradientStyle: IStyle;
+  filledNodeText: IStyle;
+  innerFrame: IStyle;
   innerOpacityToggle: IStyle;
+  linkLabel: IStyle;
+  linkLabelsTransitionGroup: IStyle;
+  linksTransitionGroup: IStyle;
+  mainFrame: IStyle;
+  node: IStyle;
+  nodeText: IStyle;
+  nodesTransitionGroup: IStyle;
+  nopointer: IStyle;
   opacityToggleRect: IStyle;
   opacityToggleCircle: IStyle;
-  errorRateGradientStyle: IStyle;
-  linksTransitionGroup: IStyle;
-  nodesTransitionGroup: IStyle;
+  svgOuterFrame: IStyle;
+  treeDescription: IStyle;
   tooltipTransitionGroup: IStyle;
-  linkLabelsTransitionGroup: IStyle;
 }
 
 export const treeViewRendererStyles: () => IProcessedStyleSet<
@@ -41,6 +42,12 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
     fontWeight: "bold",
     pointerEvents: "none",
     textAnchor: "middle"
+  };
+  const nodeTextStyle = {
+    fontSize: "10px",
+    fontWeight: "bolder",
+    pointerEvents: "none",
+    transform: "translate(0px, 0px)"
   };
   return mergeStyleSets<ITreeViewRendererStyles>({
     clickedNodeDashed: {
@@ -67,6 +74,12 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
     errorRateGradientStyle: {
       transform: "translate(100px, 60px)"
     },
+    filledNodeText: mergeStyles([
+      nodeTextStyle,
+      {
+        fill: "#FFF"
+      }
+    ]),
     innerFrame: {
       height: "100%",
       margin: "0",
@@ -107,13 +120,12 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
     nodesTransitionGroup: {
       transform: "translate(0px, 90px)"
     },
-    nodeText: {
-      fill: "#555",
-      fontSize: "10px",
-      fontWeight: "bolder",
-      pointerEvents: "none",
-      transform: "translate(0px, 0px)"
-    },
+    nodeText: mergeStyles([
+      nodeTextStyle,
+      {
+        fill: "#555"
+      }
+    ]),
     nopointer: {
       pointerEvents: "none"
     },

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -23,7 +23,7 @@ import React from "react";
 import { CSSTransition, TransitionGroup } from "react-transition-group";
 
 import { CohortStats } from "../../CohortStats";
-import { ColorPalette } from "../../ColorPalette";
+import { ColorPalette, isColorDark } from "../../ColorPalette";
 import { ErrorCohort, ErrorDetectorCohortSource } from "../../ErrorCohort";
 import { FilterProps } from "../../FilterProps";
 import { HelpMessageDict } from "../../Interfaces/IStringsParam";
@@ -385,7 +385,11 @@ export class TreeViewRenderer extends React.PureComponent<
                         </g>
                         <text
                           textAnchor="middle"
-                          className={classNames.nodeText}
+                          className={this.getNodeClassName(
+                            classNames,
+                            node.data.filterProps.errorCoverage,
+                            node.data.errorColor.fill
+                          )}
                         >
                           {node.data.error}/{node.data.size}
                         </text>
@@ -461,6 +465,18 @@ export class TreeViewRenderer extends React.PureComponent<
   public componentWillUnmount(): void {
     window.removeEventListener("resize", this.onResize.bind(this));
     this.props.setTreeViewState(this.state);
+  }
+
+  private getNodeClassName(
+    classNames: IProcessedStyleSet<ITreeViewRendererStyles>,
+    ratio: number,
+    fill: string
+  ): string {
+    let nodeTextClassName = classNames.nodeText;
+    if (ratio > 50 && isColorDark(fill)) {
+      nodeTextClassName = classNames.filledNodeText;
+    }
+    return nodeTextClassName;
   }
 
   private calculateFilterProps(


### PR DESCRIPTION
- changes node text color to white on dark color fill for better contrast (resolves https://github.com/microsoft/responsible-ai-widgets/issues/222, https://github.com/microsoft/responsible-ai-widgets/issues/173)
![image](https://user-images.githubusercontent.com/24683184/108096139-a270e600-704e-11eb-97ec-5c3633f1957b.png)
