### PR TITLE
release raiwidgets 0.2.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,13 +16,42 @@ Note that it is not required to have an entry for every pull request.
 Instead, please try to add only changes that are meaningful to users who read
 this file to understand what changed.
 
-## v-next (post-v0.2.0)
+## v-next (post-v0.2.\*)
 
 - educational materials
 - new features
 - breaking changes
 - bug fixes
 - other
+
+## v0.2.1
+
+Update to `raiwidgets` package.
+
+- educational materials:
+  - add imports for `MimicExplainer` and `PFIExplainer`
+- features
+
+  - migrate cohort and dataset utilities to core-ui
+  - remove circular dependencies
+  - convert flask comms class to function
+  - add confirmation popup in `ExplanationDashboard` when cancelling editing
+    a cohort.
+  - fix clipped dropdown in `FairnessDashboard`
+  - keep `FairnessDashboard` chart state in single model view
+  - in large data view, change `ErrorAnalysisDashboard` cohort state to use
+    full data instead of downsampled explanation data
+  - updates to `ErrorAnalysisDashboard`:
+    - add true y and predicted y values
+    - fix categorical labels handling in what if panel
+    - add breadcrumb to error explorer view and minor style adjustments to
+      navigation panel
+    - fix indexing issues for all data cohort
+    - add color column to local explanation view
+
+- pypi:
+
+  - raiwidgets: release v0.2.1
 
 ## v0.2.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,29 +29,24 @@ this file to understand what changed.
 Update to `raiwidgets` package.
 
 - educational materials:
-  - add imports for `MimicExplainer` and `PFIExplainer`
+  - add imports for `MimicExplainer` and `PFIExplainer` in the
+    interpretability-dashboard-employee-attrition notebook
 - features
-
   - migrate cohort and dataset utilities to core-ui
   - remove circular dependencies
-  - convert flask comms class to function
   - add confirmation popup in `ExplanationDashboard` when cancelling editing
     a cohort.
   - fix clipped dropdown in `FairnessDashboard`
   - keep `FairnessDashboard` chart state in single model view
-  - in large data view, change `ErrorAnalysisDashboard` cohort state to use
-    full data instead of downsampled explanation data
   - updates to `ErrorAnalysisDashboard`:
+    - in large data view, change cohort state to use full data instead
+      of downsampled explanation data
     - add true y and predicted y values
     - fix categorical labels handling in what if panel
     - add breadcrumb to error explorer view and minor style adjustments to
       navigation panel
     - fix indexing issues for all data cohort
     - add color column to local explanation view
-
-- pypi:
-
-  - raiwidgets: release v0.2.1
 
 ## v0.2.0
 

--- a/raiwidgets/setup.py
+++ b/raiwidgets/setup.py
@@ -13,7 +13,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name="raiwidgets",
-    version="0.2.0",
+    version="0.2.1",
     author="Roman Lutz, Ilya Matiach, Ke Xu",
     author_email="raiwidgets-maintain@microsoft.com",
     description="Interactive visualizations to assess fairness, explain "


### PR DESCRIPTION
updated release notes for 0.2.1 release of raiwidgets package to pypi

## v0.2.1

Update to `raiwidgets` package.

- educational materials:
  - add imports for `MimicExplainer` and `PFIExplainer`
- features

  - migrate cohort and dataset utilities to core-ui
  - remove circular dependencies
  - convert flask comms class to function
  - add confirmation popup in `ExplanationDashboard` when cancelling editing
    a cohort.
  - fix clipped dropdown in `FairnessDashboard`
  - keep `FairnessDashboard` chart state in single model view
  - in large data view, change `ErrorAnalysisDashboard` cohort state to use
    full data instead of downsampled explanation data
  - updates to `ErrorAnalysisDashboard`:
    - add true y and predicted y values
    - fix categorical labels handling in what if panel
    - add breadcrumb to error explorer view and minor style adjustments to
      navigation panel
    - fix indexing issues for all data cohort
    - add color column to local explanation view

- pypi:

  - raiwidgets: release v0.2.1