### PR TITLE
move the selected features and feature importances inside a scrollable pane and show aggregate plots by default

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ColorPalette.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ColorPalette.ts
@@ -10,7 +10,10 @@ export enum ColorPalette {
   FillStyle = "#d2d2d2",
   SelectedLineColor = "#089acc",
   UnselectedLineColor = "#e8eaed",
-  LinkLabelOutline = "#089acc"
+  LinkLabelOutline = "#089acc",
+  ErrorAnalysisLightText = "white",
+  ErrorAnalysisDarkBlackText = "rgba(0,0,0,0.8)",
+  ErrorAnalysisDarkGreyText = "#555"
 }
 
 export function isColorDark(colorStr: string): boolean {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FeatureList/FeatureList.tsx
@@ -9,10 +9,16 @@ import {
   IPanelProps,
   IPanelStyles,
   ISearchBoxStyles,
+  ISettings,
   IStackTokens,
   IStyleFunctionOrObject,
   Checkbox,
+  Customizer,
+  getId,
+  Layer,
+  LayerHost,
   Panel,
+  ScrollablePane,
   SearchBox,
   Stack,
   Text
@@ -58,6 +64,7 @@ export class FeatureList extends React.Component<
   IFeatureListProps,
   IFeatureListState
 > {
+  private layerHostId: string;
   public constructor(props: IFeatureListProps) {
     super(props);
 
@@ -71,6 +78,7 @@ export class FeatureList extends React.Component<
       selectedFeatures: this.props.features,
       sortedFeatures
     };
+    this.layerHostId = getId("featuresListHost");
   }
 
   public componentDidUpdate(prevProps: IFeatureListProps): void {
@@ -120,52 +128,78 @@ export class FeatureList extends React.Component<
                 }
               />
             </Stack.Item>
-            {this.state.searchedFeatures.map((feature) => {
-              const sortedFeatureIndex = this.state.sortedFeatures.indexOf(
-                feature
-              );
-              return (
-                <Stack.Item key={"checkboxKey" + feature}>
-                  <Stack horizontal horizontalAlign="space-between">
-                    <Stack.Item
-                      key={"checkboxItemKey" + feature}
-                      align="center"
-                    >
-                      <Checkbox
-                        label={feature}
-                        checked={this.state.selectedFeatures.includes(feature)}
-                        onChange={this.onChange.bind(this, feature)}
-                      />
-                    </Stack.Item>
-                    {this.props.importances.length > 0 &&
-                      this.props.importances[sortedFeatureIndex] !==
-                        undefined && (
-                        <Stack.Item
-                          key={"checkboxImpKey" + feature}
-                          align="center"
-                        >
-                          <svg width="100px" height="6px">
-                            <g>
-                              <rect
-                                fill={theme.palette.neutralQuaternary}
-                                width="100%"
-                                height="4"
-                                rx="5"
-                              ></rect>
-                              <rect
-                                fill={theme.palette.neutralSecondary}
-                                width={`${this.state.percents[sortedFeatureIndex]}%`}
-                                height="4"
-                                rx="5"
-                              ></rect>
-                            </g>
-                          </svg>
+            <Customizer
+              settings={(currentSettings): ISettings => ({
+                ...currentSettings,
+                hostId: this.layerHostId
+              })}
+            >
+              <Layer>
+                <ScrollablePane>
+                  <Stack
+                    tokens={checkboxStackTokens}
+                    verticalAlign="space-around"
+                  >
+                    {this.state.searchedFeatures.map((feature) => {
+                      const sortedFeatureIndex = this.state.sortedFeatures.indexOf(
+                        feature
+                      );
+                      return (
+                        <Stack.Item key={"checkboxKey" + feature}>
+                          <Stack horizontal horizontalAlign="space-between">
+                            <Stack.Item
+                              key={"checkboxItemKey" + feature}
+                              align="center"
+                            >
+                              <Checkbox
+                                label={feature}
+                                checked={this.state.selectedFeatures.includes(
+                                  feature
+                                )}
+                                onChange={this.onChange.bind(this, feature)}
+                              />
+                            </Stack.Item>
+                            {this.props.importances.length > 0 &&
+                              this.props.importances[sortedFeatureIndex] !==
+                                undefined && (
+                                <Stack.Item
+                                  key={"checkboxImpKey" + feature}
+                                  align="center"
+                                >
+                                  <svg width="100px" height="6px">
+                                    <g>
+                                      <rect
+                                        fill={theme.palette.neutralQuaternary}
+                                        width="100%"
+                                        height="4"
+                                        rx="5"
+                                      ></rect>
+                                      <rect
+                                        fill={theme.palette.neutralSecondary}
+                                        width={`${this.state.percents[sortedFeatureIndex]}%`}
+                                        height="4"
+                                        rx="5"
+                                      ></rect>
+                                    </g>
+                                  </svg>
+                                </Stack.Item>
+                              )}
+                          </Stack>
                         </Stack.Item>
-                      )}
+                      );
+                    })}
                   </Stack>
-                </Stack.Item>
-              );
-            })}
+                </ScrollablePane>
+              </Layer>
+            </Customizer>
+            <LayerHost
+              id={this.layerHostId}
+              style={{
+                height: "500px",
+                overflow: "hidden",
+                position: "relative"
+              }}
+            />
             <Stack.Item key="applyButtonKey" align="start">
               <PrimaryButton
                 text="Apply"

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
@@ -657,6 +657,8 @@ export class MatrixArea extends React.PureComponent<
   }
 
   private textColorForBackground(colorStr: string): string {
-    return isColorDark(colorStr) ? "white" : "rgba(0,0,0,0.8)";
+    return isColorDark(colorStr)
+      ? ColorPalette.ErrorAnalysisLightText
+      : ColorPalette.ErrorAnalysisDarkBlackText;
   }
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.styles.ts
@@ -8,6 +8,8 @@ import {
   mergeStyles
 } from "office-ui-fabric-react";
 
+import { ColorPalette } from "../../ColorPalette";
+
 export interface ITreeViewRendererStyles {
   clickedNodeDashed: IStyle;
   clickedNodeFull: IStyle;
@@ -77,7 +79,7 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
     filledNodeText: mergeStyles([
       nodeTextStyle,
       {
-        fill: "#FFF"
+        fill: ColorPalette.ErrorAnalysisLightText
       }
     ]),
     innerFrame: {
@@ -123,7 +125,7 @@ export const treeViewRendererStyles: () => IProcessedStyleSet<
     nodeText: mergeStyles([
       nodeTextStyle,
       {
-        fill: "#555"
+        fill: ColorPalette.ErrorAnalysisDarkGreyText
       }
     ]),
     nopointer: {

--- a/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.tsx
@@ -340,7 +340,7 @@ export class DatasetExplorerTab extends React.PureComponent<
       return;
     }
     const chartProps: IGenericChartProps = {
-      chartType: ChartTypes.Scatter,
+      chartType: ChartTypes.Histogram,
       colorAxis: {
         options: {},
         property: this.props.jointDataset.hasPredictedY

--- a/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/SidePanel.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/SidePanel.tsx
@@ -40,12 +40,12 @@ export interface ISidePanelProps {
 export class SidePanel extends React.Component<ISidePanelProps> {
   private readonly chartOptions: IChoiceGroupOption[] = [
     {
-      key: ChartTypes.Scatter,
-      text: localization.Interpret.DatasetExplorer.individualDatapoints
-    },
-    {
       key: ChartTypes.Histogram,
       text: localization.Interpret.DatasetExplorer.aggregatePlots
+    },
+    {
+      key: ChartTypes.Scatter,
+      text: localization.Interpret.DatasetExplorer.individualDatapoints
     }
   ];
   public render(): React.ReactNode {


### PR DESCRIPTION
- move the selected features and feature importances inside a scrollable pane (fixes issue https://github.com/microsoft/responsible-ai-widgets/issues/204)
![image](https://user-images.githubusercontent.com/24683184/108131822-ddd7d880-707f-11eb-8324-d8b1eb36340b.png)
- show aggregate plots by default in data explorer - NOTE (!), this will change in the explanation dashboard as well
![image](https://user-images.githubusercontent.com/24683184/108131864-f2b46c00-707f-11eb-9f1f-9d6f610de9cb.png)
