### PR TITLE
fix indexing issue in heatmap

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InspectionView/InspectionView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InspectionView/InspectionView.tsx
@@ -96,6 +96,7 @@ export class InspectionView extends React.PureComponent<
       sortArray: [],
       sortingSeriesIndex: undefined
     };
+    this.props.selectedCohort.cohort.sort();
     const cohortData = this.props.selectedCohort.cohort.filteredData;
     const numRows: number = cohortData.length;
     const viewedRows: number = Math.min(

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TabularDataView/TabularDataView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TabularDataView/TabularDataView.tsx
@@ -155,6 +155,7 @@ export class TabularDataView extends React.Component<
       );
       isCustomPointsView = true;
     } else {
+      this.props.selectedCohort.cohort.sort();
       const cohortData = this.props.selectedCohort.cohort.filteredData;
       const numRows: number = cohortData.length;
       let viewedRows: number = numRows;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/WhatIf/WhatIf.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/WhatIf/WhatIf.tsx
@@ -276,6 +276,7 @@ export class WhatIf extends React.Component<IWhatIfProps, IWhatIfState> {
     if (indexes.length === 0) {
       return undefined;
     }
+    this.props.currentCohort.cohort.sort();
     this.temporaryPoint = this.props.currentCohort.cohort.filteredData[
       indexes[0]
     ];

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorCohort.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorCohort.ts
@@ -47,6 +47,7 @@ export class ErrorCohort {
       this.totalCohortCorrect = cohortStats.totalCohortCorrect;
       this.totalCohortIncorrect = cohortStats.totalCohortIncorrect;
     } else {
+      cohort.sort();
       const filteredData = cohort.filteredData;
       this.updateStatsFromData(filteredData, jointDataset);
     }


### PR DESCRIPTION
fix indexing being out of order in certain cases (eg all cells selected in heatmap) - this issue seems similar to the indexing problem in https://github.com/microsoft/responsible-ai-widgets/pull/333 , except there we needed to make a copy of jointdataset because order on jointdataset was broken by aggregate/dataset tabs.  The jointdataset order should remain sorted by index always however.  In this case the order of the data in the cohort's filteredData is broken (not the jointdataset shared by all), but actually that is expected to happen in cases like aggregate/dataset tabs, so the best solution is to just re-sort the cohort filtered data again when it's expected to be in index order.