### PR TITLE
fix all data cohort always appearing first in cohorts lists

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -526,7 +526,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
             isOpen={this.state.openSaveCohort}
             onDismiss={(): void => this.setState({ openSaveCohort: false })}
             onSave={(savedCohort: ErrorCohort): void => {
-              let newCohorts = [savedCohort, ...this.state.cohorts];
+              let newCohorts = [...this.state.cohorts, savedCohort];
               newCohorts = newCohorts.filter((cohort) => !cohort.isTemporary);
               this.setState({
                 cohorts: newCohorts,
@@ -577,7 +577,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                 selectedCohort = editedCohort;
               }
               this.setState({
-                cohorts: [editedCohort, ...cohorts],
+                cohorts: [...cohorts, editedCohort],
                 selectedCohort
               });
             }}
@@ -606,7 +606,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
               );
               this.setState({
                 baseCohort: selectedCohort,
-                cohorts: [selectedCohort, ...cohorts],
+                cohorts: [...cohorts, selectedCohort],
                 selectedCohort
               });
             }}
@@ -680,6 +680,11 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                       cohorts={this.state.cohorts.map(
                         (errorCohort) => errorCohort.cohort
                       )}
+                      initialCohortIndex={this.state.cohorts.findIndex(
+                        (errorCohort) =>
+                          errorCohort.cohort.name ===
+                          this.state.selectedCohort.cohort.name
+                      )}
                     />
                   )}
                   {this.state.activeGlobalTab ===
@@ -700,6 +705,11 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                       weightLabels={this.state.weightVectorLabels}
                       onWeightChange={this.onWeightVectorChange}
                       explanationMethod={this.props.explanationMethod}
+                      initialCohortIndex={this.state.cohorts.findIndex(
+                        (errorCohort) =>
+                          errorCohort.cohort.name ===
+                          this.state.selectedCohort.cohort.name
+                      )}
                     />
                   )}
                   {this.state.activeGlobalTab ===
@@ -847,7 +857,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
       (errorCohort) => !errorCohort.isTemporary
     );
     if (addTemporaryCohort) {
-      cohorts = [selectedCohort, ...cohorts];
+      cohorts = [...cohorts, selectedCohort];
     }
     this.setState({ cohorts, selectedCohort });
   }

--- a/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.tsx
@@ -37,6 +37,7 @@ export interface IDatasetExplorerTabProps {
   jointDataset: JointDataset;
   metadata: IExplanationModelMetadata;
   cohorts: Cohort[];
+  initialCohortIndex?: number;
 }
 
 export interface IDatasetExplorerTabState {
@@ -56,11 +57,15 @@ export class DatasetExplorerTab extends React.PureComponent<
 
   public constructor(props: IDatasetExplorerTabProps) {
     super(props);
+    let initialCohortIndex = 0;
+    if (this.props.initialCohortIndex !== undefined) {
+      initialCohortIndex = this.props.initialCohortIndex;
+    }
     this.state = {
       calloutVisible: false,
       chartProps: this.generateDefaultChartAxes(),
       colorDialogOpen: false,
-      selectedCohortIndex: 0,
+      selectedCohortIndex: initialCohortIndex,
       xDialogOpen: false,
       yDialogOpen: false
     };

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
@@ -54,6 +54,7 @@ export interface IGlobalExplanationTabProps {
   weightLabels: Dictionary<string>;
   explanationMethod?: string;
   onWeightChange: (option: WeightVectorOption) => void;
+  initialCohortIndex?: number;
 }
 
 interface IGlobalExplanationTabState {
@@ -95,16 +96,20 @@ export class GlobalExplanationTab extends React.PureComponent<
       4,
       this.props.jointDataset.localExplanationFeatureCount
     );
+    let initialCohortIndex = 0;
+    if (this.props.initialCohortIndex !== undefined) {
+      initialCohortIndex = this.props.initialCohortIndex;
+    }
     this.state = {
       chartType: ChartTypes.Bar,
       crossClassInfoVisible: false,
       globalBarSettings: this.getDefaultSettings(),
       maxK: Math.min(30, this.props.jointDataset.localExplanationFeatureCount),
       minK,
-      selectedCohortIndex: 0,
+      selectedCohortIndex: initialCohortIndex,
       seriesIsActive: props.cohorts.map(() => true),
       sortArray: ModelExplanationUtils.getSortIndices(
-        this.props.cohorts[0].calculateAverageImportance()
+        this.props.cohorts[initialCohortIndex].calculateAverageImportance()
       ).reverse(),
       sortingSeriesIndex: 0,
       topK: minK


### PR DESCRIPTION
fixes issue https://github.com/microsoft/responsible-ai-widgets/issues/199
always make all data cohort appear first
![image](https://user-images.githubusercontent.com/24683184/108570304-86ce3f80-72db-11eb-8cb9-865f3cefef69.png)
new cohorts should only appear below in chronological order