### PR TITLE
add num selected text under local explanation radio buttons

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.styles.ts
@@ -12,6 +12,8 @@ export interface IInstanceViewStyles {
   choiceGroupContainerStyle: IStyle;
   choiceItemRootStyle: IStyle;
   page: IStyle;
+  selectedTextStyle: IStyle;
+  stackItemsStyle: IStyle;
 }
 
 export const InstanceViewStyles: () => IProcessedStyleSet<
@@ -30,6 +32,10 @@ export const InstanceViewStyles: () => IProcessedStyleSet<
     page: {
       backgroundColor: theme.semanticColors.bodyBackground,
       color: theme.semanticColors.bodyText
+    },
+    selectedTextStyle: { color: getTheme().palette.neutralPrimaryAlt },
+    stackItemsStyle: {
+      padding: "0px 0px 0px 26px"
     }
   });
 };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
@@ -8,12 +8,15 @@ import {
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import {
+  getTheme,
   IChoiceGroupOption,
   IStackItemStyles,
+  ITextSlots,
   ITheme,
   PrimaryButton,
   ChoiceGroup,
-  Stack
+  Stack,
+  Text
 } from "office-ui-fabric-react";
 import React from "react";
 
@@ -63,6 +66,12 @@ const inspectButtonStyles: IStackItemStyles = {
   }
 };
 
+enum SelectionType {
+  CorrectSelectionType = "CorrectSelectionType",
+  IncorrectSelectionType = "IncorrectSelectionType",
+  AllSelectionType = "AllSelectionType"
+}
+
 export class InstanceView extends React.Component<
   IInstanceViewProps,
   IInstanceViewState
@@ -82,6 +91,7 @@ export class InstanceView extends React.Component<
     const classNames = InstanceViewStyles();
     this.choiceItems.push({
       key: PredictionTabKeys.CorrectPredictionTab,
+      onRenderLabel: this.onRenderLabel(SelectionType.CorrectSelectionType),
       styles: {
         root: classNames.choiceItemRootStyle
       },
@@ -89,6 +99,7 @@ export class InstanceView extends React.Component<
     });
     this.choiceItems.push({
       key: PredictionTabKeys.IncorrectPredictionTab,
+      onRenderLabel: this.onRenderLabel(SelectionType.IncorrectSelectionType),
       styles: {
         root: classNames.choiceItemRootStyle
       },
@@ -96,6 +107,7 @@ export class InstanceView extends React.Component<
     });
     this.choiceItems.push({
       key: PredictionTabKeys.AllSelectedTab,
+      onRenderLabel: this.onRenderLabel(SelectionType.AllSelectionType),
       styles: {
         root: classNames.choiceItemRootStyle
       },
@@ -357,4 +369,52 @@ export class InstanceView extends React.Component<
     };
     this.setState(reloadDataFunc);
   }
+
+  private onRenderLabel = (type: SelectionType) => (
+    p: IChoiceGroupOption | undefined
+  ) => {
+    const classNames = InstanceViewStyles();
+    let selectionText = "";
+    switch (type) {
+      case SelectionType.AllSelectionType:
+        selectionText =
+          this.state.selectionDetails.selectedAllSelectedIndexes.length +
+          " selected";
+        break;
+      case SelectionType.CorrectSelectionType:
+        selectionText =
+          this.state.selectionDetails.selectedCorrectDatasetIndexes.length +
+          " selected";
+        break;
+      case SelectionType.IncorrectSelectionType:
+        selectionText =
+          this.state.selectionDetails.selectedIncorrectDatasetIndexes.length +
+          " selected";
+        break;
+      default:
+        break;
+    }
+    const stackItemStyles: IStackItemStyles = {
+      root: classNames.stackItemsStyle
+    };
+    const textStyle = {
+      root: classNames.selectedTextStyle
+    };
+    return (
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        <Stack>
+          <Stack.Item align="start">
+            <span id={p!.labelId} className="ms-ChoiceFieldLabel">
+              {p!.text}
+            </span>
+          </Stack.Item>
+          <Stack.Item align="start" styles={stackItemStyles}>
+            <Text variant="small" styles={textStyle}>
+              {selectionText}
+            </Text>
+          </Stack.Item>
+        </Stack>
+      </div>
+    );
+  };
 }


### PR DESCRIPTION
- add number of selected rows text under local explanation radio buttons
resolves issue: https://github.com/microsoft/responsible-ai-widgets/issues/251
![image](https://user-images.githubusercontent.com/24683184/108753273-87045000-7512-11eb-9e19-e84fbfe81ca5.png)
