### PR TITLE
add num selected text under local explanation radio buttons

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.styles.ts
@@ -12,6 +12,8 @@ export interface IInstanceViewStyles {
   choiceGroupContainerStyle: IStyle;
   choiceItemRootStyle: IStyle;
   page: IStyle;
+  selectedTextStyle: IStyle;
+  stackItemsStyle: IStyle;
 }
 
 export const InstanceViewStyles: () => IProcessedStyleSet<
@@ -30,6 +32,10 @@ export const InstanceViewStyles: () => IProcessedStyleSet<
     page: {
       backgroundColor: theme.semanticColors.bodyBackground,
       color: theme.semanticColors.bodyText
+    },
+    selectedTextStyle: { color: getTheme().palette.neutralPrimaryAlt },
+    stackItemsStyle: {
+      padding: "0px 0px 0px 26px"
     }
   });
 };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
@@ -13,7 +13,8 @@ import {
   ITheme,
   PrimaryButton,
   ChoiceGroup,
-  Stack
+  Stack,
+  Text
 } from "office-ui-fabric-react";
 import React from "react";
 
@@ -63,6 +64,12 @@ const inspectButtonStyles: IStackItemStyles = {
   }
 };
 
+enum SelectionType {
+  CorrectSelectionType = "CorrectSelectionType",
+  IncorrectSelectionType = "IncorrectSelectionType",
+  AllSelectionType = "AllSelectionType"
+}
+
 export class InstanceView extends React.Component<
   IInstanceViewProps,
   IInstanceViewState
@@ -82,6 +89,7 @@ export class InstanceView extends React.Component<
     const classNames = InstanceViewStyles();
     this.choiceItems.push({
       key: PredictionTabKeys.CorrectPredictionTab,
+      onRenderLabel: this.onRenderLabel(SelectionType.CorrectSelectionType),
       styles: {
         root: classNames.choiceItemRootStyle
       },
@@ -89,6 +97,7 @@ export class InstanceView extends React.Component<
     });
     this.choiceItems.push({
       key: PredictionTabKeys.IncorrectPredictionTab,
+      onRenderLabel: this.onRenderLabel(SelectionType.IncorrectSelectionType),
       styles: {
         root: classNames.choiceItemRootStyle
       },
@@ -96,6 +105,7 @@ export class InstanceView extends React.Component<
     });
     this.choiceItems.push({
       key: PredictionTabKeys.AllSelectedTab,
+      onRenderLabel: this.onRenderLabel(SelectionType.AllSelectionType),
       styles: {
         root: classNames.choiceItemRootStyle
       },
@@ -150,7 +160,7 @@ export class InstanceView extends React.Component<
             </Stack.Item>
             <Stack.Item align="end" styles={inspectButtonStyles}>
               <PrimaryButton
-                text="Inspect"
+                text={localization.ErrorAnalysis.InstanceView.inspect}
                 onClick={this.inspect.bind(this)}
                 allowDisabledFocus
                 disabled={false}
@@ -357,4 +367,53 @@ export class InstanceView extends React.Component<
     };
     this.setState(reloadDataFunc);
   }
+
+  private onRenderLabel = (type: SelectionType) => (
+    p: IChoiceGroupOption | undefined
+  ) => {
+    const classNames = InstanceViewStyles();
+    let selectionText = "";
+    switch (type) {
+      case SelectionType.AllSelectionType:
+        selectionText = localization.formatString(
+          localization.ErrorAnalysis.InstanceView.selection,
+          this.state.selectionDetails.selectedAllSelectedIndexes.length
+        );
+        break;
+      case SelectionType.CorrectSelectionType:
+        selectionText = localization.formatString(
+          localization.ErrorAnalysis.InstanceView.selection,
+          this.state.selectionDetails.selectedCorrectDatasetIndexes.length
+        );
+        break;
+      case SelectionType.IncorrectSelectionType:
+        selectionText = localization.formatString(
+          localization.ErrorAnalysis.InstanceView.selection,
+          this.state.selectionDetails.selectedIncorrectDatasetIndexes.length
+        );
+        break;
+      default:
+        break;
+    }
+    const stackItemStyles: IStackItemStyles = {
+      root: classNames.stackItemsStyle
+    };
+    const textStyle = {
+      root: classNames.selectedTextStyle
+    };
+    return (
+      <Stack>
+        <Stack.Item align="start">
+          <span id={p!.labelId} className="ms-ChoiceFieldLabel">
+            {p!.text}
+          </span>
+        </Stack.Item>
+        <Stack.Item align="start" styles={stackItemStyles}>
+          <Text variant="small" styles={textStyle}>
+            {selectionText}
+          </Text>
+        </Stack.Item>
+      </Stack>
+    );
+  };
 }

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -619,35 +619,13 @@
       "subText": "Learn about the selected cohort. Edit its cohort name. Delete this cohort.",
       "cohortName": "Cohort name"
     },
-    "ExplanationScatter": {
-      "dataLabel": "Data : {0}",
-      "_dataLabel.comment": "prepend in front of column names",
-      "importanceLabel": "Importance : {0}",
-      "_importanceLabel.comment": "prepend in front of feature importance of column name",
-      "predictedY": "Predicted Y",
-      "_predictedY.comment": "predicted output",
-      "index": "Index",
-      "_index.comment": "the index value (an integer of the row number)",
-      "dataGroupLabel": "Data",
-      "output": "Output",
-      "probabilityLabel": "Probability : {0}",
-      "_probabilityLabel.comment": "Probability prefix for all classes in a multiclass problem",
-      "trueY": "True Y",
-      "_trueY.comment": "The true value to be predicted",
-      "class": "class: ",
-      "_class.comment": "label for predicted class",
-      "xValue": "X value:",
-      "_xValue.comment": "label for x value dropdown",
-      "yValue": "Y value:",
-      "_yValue.comment": "label for y value dropdown",
-      "colorValue": "Color:",
-      "_colorValue.comment": "label for selecting color value",
-      "count": "Count",
-      "_count.comment": "the default axis is the count of items"
-    },
     "InspectionView": {
       "emptyError": "Please select datapoints in the incorrect and correct categories by clicking the checkboxes.",
       "selectedDatapoints": "Selected datapoints"
+    },
+    "InstanceView": {
+      "selection": "{0} selected",
+      "inspect": "Inspect"
     },
     "MainMenu": {
       "treeMap": "Tree map",


### PR DESCRIPTION
- add number of selected rows text under local explanation radio buttons
resolves issue: https://github.com/microsoft/responsible-ai-widgets/issues/251
![image](https://user-images.githubusercontent.com/24683184/108753273-87045000-7512-11eb-9e19-e84fbfe81ca5.png)
