### PR TITLE
Add static landing page copying to makefile to fix make html command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,4 @@ apps/*-e2e/debug.log
 /notebooks/*.zip
 
 # docs
-docs/build
+docs/build/*

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -19,5 +19,5 @@ help:
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	echo "copying static landing page"
-	cp "$(SOURCEDIR)/landing_page" "$(BUILDDIR)/html"
+	cp -r "$(SOURCEDIR)/landing_page" "$(BUILDDIR)/html"
 	echo "completed copying static landing page"

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -18,3 +18,6 @@ help:
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	echo "copying static landing page"
+	cp "$(SOURCEDIR)/landing_page" "$(BUILDDIR)/html"
+	echo "completed copying static landing page"


### PR DESCRIPTION
Currently `make html` doesn't copy over the static landing page. This will hopefully fix that part.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>