### PR TITLE
Xuke/fixglobalimportance

### DIFF
--- a/apps/dashboard-e2e/src/describer/interpret/individualFeatureImportance/describeDataPointChart.ts
+++ b/apps/dashboard-e2e/src/describer/interpret/individualFeatureImportance/describeDataPointChart.ts
@@ -33,11 +33,7 @@ export function describeDataPointChart(dataShape: IInterpretData): void {
           !dataShape.noLocalImportance && !dataShape.noFeatureImportance
             ? "Select a point to see its local importance"
             : "Provide local feature importances to see how each feature impacts individual predictions.";
-        const containerId =
-          !dataShape.noLocalImportance && !dataShape.noFeatureImportance
-            ? "#noPointSelectedInfo"
-            : "#noFeatureImportanceInfo";
-        cy.get(`${containerId}`).should("contain.text", message);
+        cy.get(`#subPlotContainer`).should("contain.text", message);
       });
       it("should select the first point", () => {
         props.chart.clickNthPoint(0);

--- a/apps/dashboard-e2e/src/describer/interpret/interpretDatasets.ts
+++ b/apps/dashboard-e2e/src/describer/interpret/interpretDatasets.ts
@@ -50,19 +50,19 @@ const interpretDatasets = {
     defaultXAxis: "Index",
     defaultYAxis: "CRIM",
     featureNames: [
-      "LSTAT",
+      "ZN",
+      "INDUS",
       "RM",
-      "PTRATIO",
-      "NOX",
       "DIS",
+      "NOX",
+      "LSTAT",
+      "RAD",
       "AGE",
       "TAX",
-      "CRIM",
+      "CHAS",
+      "PTRATIO",
       "B",
-      "INDUS",
-      "RAD",
-      "ZN",
-      "CHAS"
+      "CRIM"
     ],
     noLocalImportance: true
   },

--- a/apps/dashboard/src/interpret/__mock_data__/bostonData.ts
+++ b/apps/dashboard/src/interpret/__mock_data__/bostonData.ts
@@ -24,6 +24,21 @@ export const bostonData: IExplanationDashboardData = {
   modelInformation: { method: "regressor", modelClass: "blackbox" },
   precomputedExplanations: {
     globalFeatureImportance: {
+      featureNames: [
+        "AGE",
+        "B",
+        "CHAS",
+        "CRIM",
+        "DIS",
+        "INDUS",
+        "LSTAT",
+        "NOX",
+        "PTRATIO",
+        "RAD",
+        "RM",
+        "TAX",
+        "ZN"
+      ],
       scores: [
         0.47353925321840673,
         0.009792442047157582,

--- a/libs/core-ui/src/index.ts
+++ b/libs/core-ui/src/index.ts
@@ -14,6 +14,7 @@ export * from "./lib/util/PartialRequired";
 export * from "./lib/util/string";
 export * from "./lib/components/ConfirmationDialog";
 export * from "./lib/components/ExpandableText";
+export * from "./lib/components/MissingParametersPlaceholder";
 export * from "./lib/Interfaces/ExplanationInterfaces";
 export * from "./lib/Interfaces/IExplanationContext";
 export * from "./lib/Interfaces/IWeightedDropdownContext";

--- a/libs/core-ui/src/lib/Interfaces/ExplanationInterfaces.ts
+++ b/libs/core-ui/src/lib/Interfaces/ExplanationInterfaces.ts
@@ -39,13 +39,15 @@ export interface IDatasetSummary {
   categoricalMap?: { [key: number]: string[] };
 }
 
+export type IGlobalFeatureImportance =
+  | IMultiClassGlobalFeatureImportance
+  | ISingleClassGlobalFeatureImportance;
+
 export interface IPrecomputedExplanations {
   localFeatureImportance?:
     | IMultiClassLocalFeatureImportance
     | ISingleClassLocalFeatureImportance;
-  globalFeatureImportance?:
-    | IMultiClassGlobalFeatureImportance
-    | ISingleClassGlobalFeatureImportance;
+  globalFeatureImportance?: IGlobalFeatureImportance;
   ebmGlobalExplanation?: IEBMGlobalExplanation;
   customVis?: string;
 }
@@ -62,16 +64,19 @@ export interface IMultiClassLocalFeatureImportance {
 export interface ISingleClassLocalFeatureImportance {
   scores: number[][];
   intercept?: number;
+  featureNames?: string[];
 }
 
 export interface IMultiClassGlobalFeatureImportance {
   scores: number[][];
   intercept?: number[];
+  featureNames?: string[];
 }
 
 export interface ISingleClassGlobalFeatureImportance {
   scores: number[];
   intercept?: number;
+  featureNames?: string[];
 }
 
 export interface IBoundedCoordinates {

--- a/libs/core-ui/src/lib/components/MissingParametersPlaceholder.styles.ts
+++ b/libs/core-ui/src/lib/components/MissingParametersPlaceholder.styles.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet,
+  getTheme
+} from "office-ui-fabric-react";
+
+export interface IMissingParametersPlaceholderStyles {
+  missingParametersPlaceholder: IStyle;
+  missingParametersPlaceholderSpacer: IStyle;
+  faintText: IStyle;
+}
+
+export const missingParametersPlaceholderStyles: () => IProcessedStyleSet<
+  IMissingParametersPlaceholderStyles
+> = () => {
+  const theme = getTheme();
+  return mergeStyleSets<IMissingParametersPlaceholderStyles>({
+    faintText: {
+      fontWeight: "350"
+    },
+    missingParametersPlaceholder: {
+      height: "300px",
+      width: "100%"
+    },
+    missingParametersPlaceholderSpacer: {
+      boxShadow: theme.effects.elevation4,
+      margin: "25px auto 0 auto",
+      maxWidth: "400px",
+      padding: "23px",
+      width: "fit-content"
+    }
+  });
+};

--- a/libs/core-ui/src/lib/components/MissingParametersPlaceholder.tsx
+++ b/libs/core-ui/src/lib/components/MissingParametersPlaceholder.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Text } from "office-ui-fabric-react";
+import React from "react";
+
+import { missingParametersPlaceholderStyles } from "./MissingParametersPlaceholder.styles";
+
+export interface IMissingParametersPlaceholderProps {
+  children: string;
+}
+
+export class MissingParametersPlaceholder extends React.Component<
+  IMissingParametersPlaceholderProps
+> {
+  public render(): React.ReactNode {
+    const classNames = missingParametersPlaceholderStyles();
+    return (
+      <div className={classNames.missingParametersPlaceholder}>
+        <div className={classNames.missingParametersPlaceholderSpacer}>
+          <Text variant="large" className={classNames.faintText}>
+            {this.props.children}
+          </Text>
+        </div>
+      </div>
+    );
+  }
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -624,10 +624,6 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                     <GlobalExplanationTab
                       jointDataset={this.state.jointDataset}
                       metadata={this.state.modelMetadata}
-                      globalImportance={this.state.globalImportance}
-                      isGlobalDerivedFromLocal={
-                        this.state.isGlobalImportanceDerivedFromLocal
-                      }
                       cohorts={this.state.cohorts.map(
                         (errorCohort) => errorCohort.cohort
                       )}

--- a/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.styles.ts
@@ -34,9 +34,6 @@ export interface IDatasetExplorerTabStyles {
   legend: IStyle;
   callout: IStyle;
   chartEditorButton: IStyle;
-  missingParametersPlaceholder: IStyle;
-  missingParametersPlaceholderSpacer: IStyle;
-  faintText: IStyle;
   smallItalic: IStyle;
 }
 
@@ -102,7 +99,6 @@ export const datasetExplorerTabStyles: () => IProcessedStyleSet<
       margin: "11px 4px 11px 8px",
       width: "12px"
     },
-    faintText: [FabricStyles.faintText],
     helperText: {
       paddingLeft: "15px",
       paddingRight: "160px"
@@ -149,10 +145,6 @@ export const datasetExplorerTabStyles: () => IProcessedStyleSet<
       height: "600px",
       width: "100%"
     },
-    missingParametersPlaceholder: [FabricStyles.missingParameterPlaceholder],
-    missingParametersPlaceholderSpacer: [
-      FabricStyles.missingParameterPlaceholderSpacer
-    ],
     paddingDiv: {
       width: "50px"
     },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/DatasetExplorerTab/DatasetExplorerTab.tsx
@@ -10,7 +10,8 @@ import {
   IExplanationModelMetadata,
   ChartTypes,
   IGenericChartProps,
-  ISelectorConfig
+  ISelectorConfig,
+  MissingParametersPlaceholder
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { AccessibleChart } from "@responsible-ai/mlchartlib";
@@ -78,13 +79,9 @@ export class DatasetExplorerTab extends React.PureComponent<
 
     if (!this.props.jointDataset.hasDataset) {
       return (
-        <div className={classNames.missingParametersPlaceholder}>
-          <div className={classNames.missingParametersPlaceholderSpacer}>
-            <Text variant="large" className={classNames.faintText}>
-              {localization.Interpret.DatasetExplorer.missingParameters}
-            </Text>
-          </div>
-        </div>
+        <MissingParametersPlaceholder>
+          {localization.Interpret.DatasetExplorer.missingParameters}
+        </MissingParametersPlaceholder>
       );
     }
     if (this.state.chartProps === undefined) {
@@ -216,19 +213,9 @@ export class DatasetExplorerTab extends React.PureComponent<
               {canRenderChart ? (
                 <AccessibleChart plotlyProps={plotlyProps} theme={getTheme()} />
               ) : (
-                <div className={classNames.missingParametersPlaceholder}>
-                  <div
-                    className={classNames.missingParametersPlaceholderSpacer}
-                  >
-                    <Text
-                      block
-                      variant="large"
-                      className={classNames.faintText}
-                    >
-                      {localization.Interpret.ValidationErrors.datasizeError}
-                    </Text>
-                  </div>
-                </div>
+                <MissingParametersPlaceholder>
+                  {localization.Interpret.ValidationErrors.datasizeError}
+                </MissingParametersPlaceholder>
               )}
             </div>
             <div className={classNames.horizontalAxisWithPadding}>

--- a/libs/interpret/src/lib/MLIDashboard/Controls/FeatureImportanceBar/FeatureImportanceBar.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/FeatureImportanceBar/FeatureImportanceBar.tsx
@@ -29,6 +29,7 @@ export interface IFeatureBarProps {
   unsortedX: string[];
   unsortedSeries: IGlobalSeries[];
   originX?: string[];
+  xMapping?: string[];
   onFeatureSelection?: (seriesIndex: number, featureIndex: number) => void;
 }
 

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.styles.ts
@@ -24,9 +24,6 @@ export interface IGlobalTabStyles {
   cohortLegend: IStyle;
   legendHelpText: IStyle;
   secondaryChartAndLegend: IStyle;
-  missingParametersPlaceholder: IStyle;
-  missingParametersPlaceholderSpacer: IStyle;
-  faintText: IStyle;
   chartEditorButton: IStyle;
   boldText: IStyle;
   cohortLegendWithTop: IStyle;
@@ -60,7 +57,6 @@ export const globalTabStyles: () => IProcessedStyleSet<
       paddingBottom: "10px",
       paddingTop: "10px"
     },
-    faintText: [FabricStyles.faintText],
     globalChartControls: {
       display: "flex",
       flexDirection: "row",
@@ -96,10 +92,6 @@ export const globalTabStyles: () => IProcessedStyleSet<
     legendHelpText: {
       fontWeight: "300"
     },
-    missingParametersPlaceholder: [FabricStyles.missingParameterPlaceholder],
-    missingParametersPlaceholderSpacer: [
-      FabricStyles.missingParameterPlaceholderSpacer
-    ],
     page: {
       boxSizing: "border-box",
       display: "flex",

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
@@ -9,7 +9,8 @@ import {
   IExplanationModelMetadata,
   ModelExplanationUtils,
   ChartTypes,
-  IGenericChartProps
+  IGenericChartProps,
+  MissingParametersPlaceholder
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { Dictionary } from "lodash";
@@ -132,23 +133,7 @@ export class GlobalExplanationTab extends React.PureComponent<
     const classNames = globalTabStyles();
 
     if (!this.props.jointDataset.hasLocalExplanations) {
-      if (this.props.globalImportance !== undefined) {
-        return (
-          <GlobalOnlyChart
-            metadata={this.props.metadata}
-            globalImportance={this.props.globalImportance}
-          />
-        );
-      }
-      return (
-        <div className={classNames.missingParametersPlaceholder}>
-          <div className={classNames.missingParametersPlaceholderSpacer}>
-            <Text variant="large" className={classNames.faintText}>
-              {localization.Interpret.GlobalTab.missingParameters}
-            </Text>
-          </div>
-        </div>
-      );
+      return <GlobalOnlyChart />;
     }
 
     if (this.state.globalBarSettings === undefined) {
@@ -245,13 +230,9 @@ export class GlobalExplanationTab extends React.PureComponent<
           />
         </div>
         {!this.hasDataset && (
-          <div className={classNames.missingParametersPlaceholder}>
-            <div className={classNames.missingParametersPlaceholderSpacer}>
-              <Text variant="large" className={classNames.faintText}>
-                {localization.Interpret.GlobalTab.datasetRequired}
-              </Text>
-            </div>
-          </div>
+          <MissingParametersPlaceholder>
+            {localization.Interpret.GlobalTab.datasetRequired}
+          </MissingParametersPlaceholder>
         )}
         {this.hasDataset && (
           <div>
@@ -381,7 +362,7 @@ export class GlobalExplanationTab extends React.PureComponent<
       4
     );
     result.sortOption = "global";
-    result.includeOverallGlobal = !this.props.isGlobalDerivedFromLocal;
+    result.includeOverallGlobal = true;
     return result;
   }
 

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
@@ -45,8 +45,6 @@ export interface IGlobalBarSettings {
 export interface IGlobalExplanationTabProps {
   jointDataset: JointDataset;
   metadata: IExplanationModelMetadata;
-  globalImportance?: number[][];
-  isGlobalDerivedFromLocal: boolean;
   cohorts: Cohort[];
   cohortIDs: string[];
   selectedWeightVector: WeightVectorOption;

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalOnlyChart/GlobalOnlyChart.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalOnlyChart/GlobalOnlyChart.tsx
@@ -133,7 +133,7 @@ export class GlobalOnlyChart extends React.PureComponent<
             ]}
             sortArray={this.state.sortArray}
             chartType={ChartTypes.Bar}
-            unsortedX={this.context.modelMetadata.featureNamesAbridged}
+            unsortedX={this.state.featureNames}
             unsortedSeries={this.state.globalSeries}
             topK={this.state.topK}
           />

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalOnlyChart/GlobalOnlyChart.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalOnlyChart/GlobalOnlyChart.tsx
@@ -2,87 +2,98 @@
 // Licensed under the MIT License.
 
 import {
-  IExplanationModelMetadata,
   ModelExplanationUtils,
-  ChartTypes
+  ChartTypes,
+  MissingParametersPlaceholder,
+  isTwoDimArray,
+  IGlobalFeatureImportance
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
-import { IDropdownOption, Icon, Slider, Text } from "office-ui-fabric-react";
+import { Icon, Slider, Text } from "office-ui-fabric-react";
 import React from "react";
 
+import {
+  defaultInterpretContext,
+  InterpretContext
+} from "../../context/InterpretContext";
 import { FeatureKeys } from "../../SharedComponents/IBarChartConfig";
 import { FeatureImportanceBar } from "../FeatureImportanceBar/FeatureImportanceBar";
 import { globalTabStyles } from "../GlobalExplanationTab/GlobalExplanationTab.styles";
 import { IGlobalSeries } from "../GlobalExplanationTab/IGlobalSeries";
 
-export interface IGlobalOnlyChartProps {
-  metadata: IExplanationModelMetadata;
-  globalImportance?: number[][];
-}
-
 export interface IGlobalOnlyChartState {
   topK: number;
   sortingSeriesKey: number | string;
   sortArray: number[];
+  globalSeries: IGlobalSeries[];
+  featureNames: string[];
 }
 
 export class GlobalOnlyChart extends React.PureComponent<
-  IGlobalOnlyChartProps,
+  unknown,
   IGlobalOnlyChartState
 > {
-  private readonly featureDimension = this.props.metadata.featureNames.length;
-  private readonly perClassExplanationDimension =
-    this.props.globalImportance && this.props.globalImportance[0]
-      ? this.props.globalImportance[0].length
-      : 0;
-  private readonly minK = Math.min(4, this.featureDimension);
-  private classOptions: IDropdownOption[];
-  // look into per_class importances when available.
-  // if explanation class dimension is singular,
-  private readonly globalSeries: IGlobalSeries[] =
-    this.perClassExplanationDimension === 1
-      ? [
-          {
-            colorIndex: 0,
-            name: localization.Interpret.BarChart.absoluteGlobal,
-            unsortedAggregateY:
-              this.props.globalImportance?.map((classArray) => classArray[0]) ||
-              []
-          }
-        ]
-      : this.props.metadata.classNames.map((name, index) => {
-          return {
-            colorIndex: index,
-            name,
-            unsortedAggregateY:
-              this.props.globalImportance?.map(
-                (classArray) => classArray[index]
-              ) || []
-          };
-        });
+  public static contextType = InterpretContext;
+  public context: React.ContextType<
+    typeof InterpretContext
+  > = defaultInterpretContext;
 
-  public constructor(props: IGlobalOnlyChartProps) {
-    super(props);
-
-    this.classOptions = this.props.metadata.classNames.map(
-      (className, index) => {
-        return { key: index, text: className };
-      }
+  public componentDidMount(): void {
+    if (
+      !this.context.precomputedExplanations?.globalFeatureImportance?.scores
+        ?.length
+    ) {
+      return;
+    }
+    const globalImportance = this.buildGlobalProperties(
+      this.context.precomputedExplanations?.globalFeatureImportance
     );
-    this.classOptions.unshift({
-      key: FeatureKeys.AbsoluteGlobal,
-      text: localization.Interpret.BarChart.absoluteGlobal
-    });
-    this.state = {
+    const perClassExplanationDimension = globalImportance[0].length || 0;
+    this.setState({
+      featureNames:
+        this.context.precomputedExplanations.globalFeatureImportance
+          .featureNames || this.context.modelMetadata.featureNamesAbridged,
+      globalSeries:
+        perClassExplanationDimension === 1
+          ? [
+              {
+                colorIndex: 0,
+                name: localization.Interpret.BarChart.absoluteGlobal,
+                unsortedAggregateY:
+                  globalImportance?.map((classArray) => classArray[0]) || []
+              }
+            ]
+          : this.context.modelMetadata.classNames.map((name, index) => {
+              return {
+                colorIndex: index,
+                name,
+                unsortedAggregateY:
+                  globalImportance.map((classArray) => classArray[index]) || []
+              };
+            }),
       sortArray: ModelExplanationUtils.buildSortedVector(
-        this.props.globalImportance || []
+        globalImportance
       ).reverse(),
       sortingSeriesKey: FeatureKeys.AbsoluteGlobal,
-      topK: this.minK
-    };
+      topK: Math.min(
+        4,
+        this.context.precomputedExplanations?.globalFeatureImportance?.scores
+          .length || 0
+      )
+    });
   }
 
   public render(): React.ReactNode {
+    if (!this.context.precomputedExplanations?.globalFeatureImportance) {
+      return (
+        <MissingParametersPlaceholder>
+          {localization.Interpret.GlobalTab.missingParameters}
+        </MissingParametersPlaceholder>
+      );
+    }
+    if (!this.state) {
+      return React.Fragment;
+    }
     const classNames = globalTabStyles();
     return (
       <div className={classNames.page}>
@@ -103,7 +114,10 @@ export class GlobalOnlyChart extends React.PureComponent<
           <Slider
             className={classNames.startingK}
             ariaLabel={localization.Interpret.AggregateImportance.topKFeatures}
-            max={this.featureDimension}
+            max={
+              this.context.precomputedExplanations.globalFeatureImportance
+                .scores.length
+            }
             min={1}
             step={1}
             value={this.state.topK}
@@ -119,8 +133,8 @@ export class GlobalOnlyChart extends React.PureComponent<
             ]}
             sortArray={this.state.sortArray}
             chartType={ChartTypes.Bar}
-            unsortedX={this.props.metadata.featureNamesAbridged}
-            unsortedSeries={this.globalSeries}
+            unsortedX={this.context.modelMetadata.featureNamesAbridged}
+            unsortedSeries={this.state.globalSeries}
             topK={this.state.topK}
           />
         </div>
@@ -131,4 +145,16 @@ export class GlobalOnlyChart extends React.PureComponent<
   private setTopK = (newValue: number): void => {
     this.setState({ topK: newValue });
   };
+
+  private buildGlobalProperties(
+    globalFeatureImportance: IGlobalFeatureImportance
+  ): number[][] {
+    let globalImportance: number[][];
+    if (isTwoDimArray(globalFeatureImportance.scores)) {
+      globalImportance = globalFeatureImportance.scores;
+    } else {
+      globalImportance = globalFeatureImportance.scores.map((value) => [value]);
+    }
+    return globalImportance;
+  }
 }

--- a/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.styles.ts
@@ -30,10 +30,6 @@ export interface IModelPerformanceTabStyles {
   cohortPickerWrapper: IStyle;
   cohortPickerLabel: IStyle;
   boldText: IStyle;
-  missingParametersPlaceholder: IStyle;
-  missingParametersPlaceholderSpacer: IStyle;
-  missingParametersPlaceholderNeutralSpacer: IStyle;
-  faintText: IStyle;
 }
 
 export const modelPerformanceTabStyles: () => IProcessedStyleSet<
@@ -72,7 +68,6 @@ export const modelPerformanceTabStyles: () => IProcessedStyleSet<
       paddingLeft: "63px",
       paddingTop: "13px"
     },
-    faintText: [FabricStyles.faintText],
     helperText: {
       paddingLeft: "15px",
       paddingRight: "160px"
@@ -98,16 +93,6 @@ export const modelPerformanceTabStyles: () => IProcessedStyleSet<
       paddingLeft: "25px",
       width: "100%"
     },
-    missingParametersPlaceholder: [FabricStyles.missingParameterPlaceholder],
-    missingParametersPlaceholderNeutralSpacer: [
-      FabricStyles.missingParameterPlaceholderSpacer,
-      {
-        backgroundColor: theme.semanticColors.bodyBackground
-      }
-    ],
-    missingParametersPlaceholderSpacer: [
-      FabricStyles.missingParameterPlaceholderSpacer
-    ],
     paddingDiv: {
       width: "50px"
     },

--- a/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.styles.ts
@@ -8,8 +8,6 @@ import {
   getTheme
 } from "office-ui-fabric-react";
 
-import { FabricStyles } from "../../FabricStyles";
-
 export interface IModelPerformanceTabStyles {
   page: IStyle;
   infoIcon: IStyle;

--- a/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/ModelPerformanceTab/ModelPerformanceTab.tsx
@@ -11,7 +11,8 @@ import {
   Cohort,
   ChartTypes,
   IGenericChartProps,
-  ISelectorConfig
+  ISelectorConfig,
+  MissingParametersPlaceholder
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { AccessibleChart, IPlotlyProperty } from "@responsible-ai/mlchartlib";
@@ -221,13 +222,9 @@ export class ModelPerformanceTab extends React.PureComponent<
     const classNames = modelPerformanceTabStyles();
     if (!this.props.jointDataset.hasPredictedY) {
       return (
-        <div className={classNames.missingParametersPlaceholder}>
-          <div className={classNames.missingParametersPlaceholderSpacer}>
-            <Text variant="large" className={classNames.faintText}>
-              {localization.Interpret.ModelPerformance.missingParameters}
-            </Text>
-          </div>
-        </div>
+        <MissingParametersPlaceholder>
+          {localization.Interpret.ModelPerformance.missingParameters}
+        </MissingParametersPlaceholder>
       );
     }
     if (this.state.chartProps === undefined) {
@@ -335,23 +332,9 @@ export class ModelPerformanceTab extends React.PureComponent<
                 {this.props.metadata.modelType !== ModelTypes.Multiclass && (
                   <div className={classNames.rightPanel}>
                     {!this.props.jointDataset.hasTrueY && (
-                      <div className={classNames.missingParametersPlaceholder}>
-                        <div
-                          className={
-                            classNames.missingParametersPlaceholderNeutralSpacer
-                          }
-                        >
-                          <Text
-                            variant="large"
-                            className={classNames.faintText}
-                          >
-                            {
-                              localization.Interpret.ModelPerformance
-                                .missingTrueY
-                            }
-                          </Text>
-                        </div>
-                      </div>
+                      <MissingParametersPlaceholder>
+                        {localization.Interpret.ModelPerformance.missingTrueY}
+                      </MissingParametersPlaceholder>
                     )}
                     {this.props.jointDataset.hasTrueY &&
                       metricsList.map((stats, index) => {

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/LocalImportancePlots.tsx
@@ -7,7 +7,8 @@ import {
   WeightVectorOption,
   JointDataset,
   ModelExplanationUtils,
-  ChartTypes
+  ChartTypes,
+  MissingParametersPlaceholder
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import {
@@ -128,30 +129,18 @@ export class LocalImportancePlots extends React.Component<
     ) {
       if (!this.props.jointDataset.hasLocalExplanations) {
         secondaryPlot = (
-          <div
-            className={classNames.missingParametersPlaceholder}
-            id="noFeatureImportanceInfo"
-          >
-            <div className={classNames.missingParametersPlaceholderSpacer}>
-              <Text variant="large" className={classNames.faintText}>
-                {
-                  localization.Interpret.WhatIfTab
-                    .featureImportanceLackingParameters
-                }
-              </Text>
-            </div>
-          </div>
+          <MissingParametersPlaceholder>
+            {
+              localization.Interpret.WhatIfTab
+                .featureImportanceLackingParameters
+            }
+          </MissingParametersPlaceholder>
         );
       } else if (this.props.includedFeatureImportance.length === 0) {
         secondaryPlot = (
-          <div
-            className={classNames.missingParametersPlaceholder}
-            id="noPointSelectedInfo"
-          >
-            <Text>
-              {localization.Interpret.WhatIfTab.featureImportanceGetStartedText}
-            </Text>
-          </div>
+          <MissingParametersPlaceholder>
+            {localization.Interpret.WhatIfTab.featureImportanceGetStartedText}
+          </MissingParametersPlaceholder>
         );
       } else {
         const yAxisLabels: string[] = [
@@ -285,23 +274,15 @@ export class LocalImportancePlots extends React.Component<
       }
     } else if (!this.props.invokeModel) {
       secondaryPlot = (
-        <div className={classNames.missingParametersPlaceholder}>
-          <div className={classNames.missingParametersPlaceholderSpacer}>
-            <Text variant="large" className={classNames.faintText}>
-              {localization.Interpret.WhatIfTab.iceLackingParameters}
-            </Text>
-          </div>
-        </div>
+        <MissingParametersPlaceholder>
+          {localization.Interpret.WhatIfTab.iceLackingParameters}
+        </MissingParametersPlaceholder>
       );
     } else if (this.props.testableDatapoints.length === 0) {
       secondaryPlot = (
-        <div className={classNames.missingParametersPlaceholder}>
-          <div className={classNames.missingParametersPlaceholderSpacer}>
-            <Text variant="large" className={classNames.faintText}>
-              {localization.Interpret.WhatIfTab.IceGetStartedText}
-            </Text>
-          </div>
-        </div>
+        <MissingParametersPlaceholder>
+          {localization.Interpret.WhatIfTab.IceGetStartedText}
+        </MissingParametersPlaceholder>
       );
     } else {
       secondaryPlot = (

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.styles.ts
@@ -49,9 +49,6 @@ export interface IWhatIfTabStyles {
   choiceGroup: IStyle;
   choiceGroupFlexContainer: IStyle;
   panelIconAndLabel: IStyle;
-  missingParametersPlaceholder: IStyle;
-  missingParametersPlaceholderSpacer: IStyle;
-  faintText: IStyle;
   predictedBlock: IStyle;
   upperWhatIfPanel: IStyle;
   saveButton: IStyle;
@@ -60,7 +57,6 @@ export interface IWhatIfTabStyles {
   iceFeatureSelection: IStyle;
   iceClassSelection: IStyle;
   disclaimerWrapper: IStyle;
-  panelPlaceholderWrapper: IStyle;
   errorText: IStyle;
   tooltipColumn: IStyle;
   tooltipTable: IStyle;
@@ -180,7 +176,6 @@ export const whatIfTabStyles: () => IProcessedStyleSet<
       width: "250px",
       zIndex: 99999
     },
-    faintText: [FabricStyles.faintText],
     featureImportanceArea: {
       width: "100%"
     },
@@ -274,10 +269,6 @@ export const whatIfTabStyles: () => IProcessedStyleSet<
       flexDirection: "row-reverse",
       minHeight: "800px"
     },
-    missingParametersPlaceholder: [FabricStyles.missingParameterPlaceholder],
-    missingParametersPlaceholderSpacer: [
-      FabricStyles.missingParameterPlaceholderSpacer
-    ],
     multiclassWeightLabel: {
       display: "inline-flex",
       paddingTop: "10px"
@@ -305,13 +296,6 @@ export const whatIfTabStyles: () => IProcessedStyleSet<
       display: "flex",
       paddingTop: "10px"
     },
-    panelPlaceholderWrapper: [
-      FabricStyles.missingParameterPlaceholder,
-      {
-        boxSizing: "border-box",
-        padding: "0 16px"
-      }
-    ],
     parameterList: {
       backgroundColor: theme.palette.neutralLighter,
       display: "flex",

--- a/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/WhatIfTab/WhatIfTab.tsx
@@ -11,7 +11,8 @@ import {
   ModelExplanationUtils,
   ChartTypes,
   IGenericChartProps,
-  ISelectorConfig
+  ISelectorConfig,
+  MissingParametersPlaceholder
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import {
@@ -291,13 +292,9 @@ export class WhatIfTab extends React.PureComponent<
     const classNames = whatIfTabStyles();
     if (!this.props.jointDataset.hasDataset) {
       return (
-        <div className={classNames.missingParametersPlaceholder}>
-          <div className={classNames.missingParametersPlaceholderSpacer}>
-            <Text variant="large" className={classNames.faintText}>
-              {localization.Interpret.WhatIfTab.missingParameters}
-            </Text>
-          </div>
-        </div>
+        <MissingParametersPlaceholder>
+          {localization.Interpret.WhatIfTab.missingParameters}
+        </MissingParametersPlaceholder>
       );
     }
     if (this.state.chartProps === undefined) {
@@ -436,24 +433,9 @@ export class WhatIfTab extends React.PureComponent<
                     </div>
                   </div>
                   {!canRenderChart && (
-                    <div className={classNames.missingParametersPlaceholder}>
-                      <div
-                        className={
-                          classNames.missingParametersPlaceholderSpacer
-                        }
-                      >
-                        <Text
-                          block
-                          variant="large"
-                          className={classNames.faintText}
-                        >
-                          {
-                            localization.Interpret.ValidationErrors
-                              .datasizeError
-                          }
-                        </Text>
-                      </div>
-                    </div>
+                    <MissingParametersPlaceholder>
+                      {localization.Interpret.ValidationErrors.datasizeError}
+                    </MissingParametersPlaceholder>
                   )}
                   {canRenderChart && (
                     <AccessibleChart

--- a/libs/interpret/src/lib/MLIDashboard/FabricStyles.ts
+++ b/libs/interpret/src/lib/MLIDashboard/FabricStyles.ts
@@ -72,11 +72,6 @@ export class FabricStyles {
     FabricStyles.limitedSizeMenuDropdown
   );
 
-  public static missingParameterPlaceholder: IStyle = {
-    height: "300px",
-    width: "100%"
-  };
-
   public static calloutWrapper: IStyle = {
     width: "300px"
   };
@@ -128,18 +123,6 @@ export class FabricStyles {
     color: getTheme().semanticColors.disabledBodyText,
     fontStyle: "italic",
     padding: "0 0 5px 5px"
-  };
-
-  public static missingParameterPlaceholderSpacer: IStyle = {
-    boxShadow: getTheme().effects.elevation4,
-    margin: "25px auto 0 auto",
-    maxWidth: "400px",
-    padding: "23px",
-    width: "fit-content"
-  };
-
-  public static faintText: IStyle = {
-    fontWeight: "350" as any
   };
 
   public static plotlyColorPalette: IRGBColor[] = [

--- a/libs/interpret/src/lib/MLIDashboard/Interfaces/IExplanationDashboardProps.ts
+++ b/libs/interpret/src/lib/MLIDashboard/Interfaces/IExplanationDashboardProps.ts
@@ -52,9 +52,6 @@ export interface INewExplanationDashboardState {
   activeGlobalTab: GlobalTabKeys;
   jointDataset: JointDataset;
   modelMetadata: IExplanationModelMetadata;
-  globalImportanceIntercept: number[];
-  globalImportance: number[][];
-  isGlobalImportanceDerivedFromLocal: boolean;
   validationWarnings: string[];
   showingDataSizeWarning: boolean;
   selectedWeightVector: WeightVectorOption;

--- a/libs/interpret/src/lib/MLIDashboard/NewExplanationDashboard.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/NewExplanationDashboard.tsx
@@ -78,8 +78,8 @@ export class NewExplanationDashboard extends React.PureComponent<
       <InterpretContext.Provider
         value={{
           cohorts: this.state.cohorts,
-          globalImportance: this.state.globalImportance,
-          globalImportanceIntercept: this.state.globalImportanceIntercept,
+          globalImportance: this.props.precomputedExplanations
+            ?.globalFeatureImportance,
           jointDataset: this.state.jointDataset,
           requestLocalFeatureExplanations: this.props
             .requestLocalFeatureExplanations,
@@ -170,10 +170,6 @@ export class NewExplanationDashboard extends React.PureComponent<
                     <GlobalExplanationTab
                       jointDataset={this.state.jointDataset}
                       metadata={this.state.modelMetadata}
-                      globalImportance={this.state.globalImportance}
-                      isGlobalDerivedFromLocal={
-                        this.state.isGlobalImportanceDerivedFromLocal
-                      }
                       cohorts={this.state.cohorts}
                       cohortIDs={cohortIDs}
                       selectedWeightVector={this.state.selectedWeightVector}

--- a/libs/interpret/src/lib/MLIDashboard/NewExplanationDashboard.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/NewExplanationDashboard.tsx
@@ -78,9 +78,9 @@ export class NewExplanationDashboard extends React.PureComponent<
       <InterpretContext.Provider
         value={{
           cohorts: this.state.cohorts,
-          globalImportance: this.props.precomputedExplanations
-            ?.globalFeatureImportance,
           jointDataset: this.state.jointDataset,
+          modelMetadata: this.state.modelMetadata,
+          precomputedExplanations: this.props.precomputedExplanations,
           requestLocalFeatureExplanations: this.props
             .requestLocalFeatureExplanations,
           requestPredictions: this.state.requestPredictions,

--- a/libs/interpret/src/lib/MLIDashboard/buildInitialExplanationContext.ts
+++ b/libs/interpret/src/lib/MLIDashboard/buildInitialExplanationContext.ts
@@ -8,8 +8,7 @@ import {
   WeightVectors,
   JointDataset,
   IExplanationModelMetadata,
-  ModelTypes,
-  isTwoDimArray
+  ModelTypes
 } from "@responsible-ai/core-ui";
 import { localization } from "@responsible-ai/localization";
 import { ModelMetadata } from "@responsible-ai/mlchartlib";
@@ -19,7 +18,6 @@ import {
   IExplanationDashboardProps,
   INewExplanationDashboardState
 } from "./Interfaces/IExplanationDashboardProps";
-import { IGlobalExplanationProps } from "./Interfaces/IGlobalExplanationProps";
 import { TelemetryLevels } from "./Interfaces/ITelemetryMessage";
 import { getClassLength } from "./utils/getClassLength";
 import { ValidateProperties } from "./ValidateProperties";
@@ -127,48 +125,6 @@ function buildModelMetadata(
   };
 }
 
-function buildGlobalProperties(
-  props: IExplanationDashboardProps
-): IGlobalExplanationProps | undefined {
-  if (
-    props.precomputedExplanations &&
-    props.precomputedExplanations.globalFeatureImportance &&
-    props.precomputedExplanations.globalFeatureImportance.scores
-  ) {
-    let globalImportance: number[][];
-    let globalImportanceIntercept: number[] | undefined;
-    if (
-      isTwoDimArray(
-        props.precomputedExplanations.globalFeatureImportance.scores
-      )
-    ) {
-      globalImportance =
-        props.precomputedExplanations.globalFeatureImportance.scores;
-      globalImportanceIntercept = props.precomputedExplanations
-        .globalFeatureImportance.intercept as number[];
-    } else {
-      globalImportance = props.precomputedExplanations.globalFeatureImportance.scores.map(
-        (value) => [value]
-      );
-      globalImportanceIntercept = props.precomputedExplanations
-        .globalFeatureImportance
-        ? [
-            props.precomputedExplanations.globalFeatureImportance
-              .intercept as number
-          ]
-        : undefined;
-    }
-    return {
-      globalImportance,
-      globalImportanceFeatureNames:
-        props.precomputedExplanations.globalFeatureImportance.featureNames ||
-        props.dataSummary.featureNames,
-      globalImportanceIntercept,
-      isGlobalImportanceDerivedFromLocal: false
-    };
-  }
-  return undefined;
-}
 export function buildInitialExplanationContext(
   props: IExplanationDashboardProps
 ): INewExplanationDashboardState {
@@ -190,7 +146,6 @@ export function buildInitialExplanationContext(
     predictedY: props.predictedY,
     trueY: props.trueY
   });
-  const globalProps = buildGlobalProperties(props);
   // consider taking filters in as param arg for programmatic users
   const cohorts = [
     new Cohort(localization.Interpret.Cohort.defaultLabel, jointDataset, [])
@@ -222,11 +177,6 @@ export function buildInitialExplanationContext(
   return {
     activeGlobalTab: GlobalTabKeys.ModelPerformance,
     cohorts,
-    globalImportance: globalProps?.globalImportance,
-    globalImportanceFeatureNames: globalProps?.globalImportanceFeatureNames,
-    globalImportanceIntercept: globalProps?.globalImportanceIntercept,
-    isGlobalImportanceDerivedFromLocal:
-      globalProps?.isGlobalImportanceDerivedFromLocal || false,
     jointDataset,
     modelMetadata,
     selectedWeightVector:

--- a/libs/interpret/src/lib/MLIDashboard/context/InterpretContext.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/context/InterpretContext.tsx
@@ -3,7 +3,8 @@
 
 import {
   Cohort,
-  IGlobalFeatureImportance,
+  IExplanationModelMetadata,
+  IPrecomputedExplanations,
   JointDataset
 } from "@responsible-ai/core-ui";
 import React from "react";
@@ -12,8 +13,9 @@ import { ITelemetryMessage } from "../Interfaces/ITelemetryMessage";
 
 export interface IInterpretContext {
   cohorts: Cohort[];
-  globalImportance?: IGlobalFeatureImportance;
+  precomputedExplanations?: IPrecomputedExplanations;
   jointDataset: JointDataset;
+  modelMetadata: IExplanationModelMetadata;
   telemetryHook: (message: ITelemetryMessage) => void;
   requestPredictions:
     | ((request: any[], abortSignal: AbortSignal) => Promise<any[]>)
@@ -27,12 +29,16 @@ export interface IInterpretContext {
     | undefined;
 }
 
-const interpretContext = React.createContext<IInterpretContext>({
+export const defaultInterpretContext: IInterpretContext = {
   cohorts: [],
-  globalImportance: undefined,
   jointDataset: {} as JointDataset,
+  modelMetadata: {} as IExplanationModelMetadata,
+  precomputedExplanations: undefined,
   requestLocalFeatureExplanations: undefined,
   requestPredictions: undefined,
   telemetryHook: () => undefined
-});
+};
+const interpretContext = React.createContext<IInterpretContext>(
+  defaultInterpretContext
+);
 export { interpretContext as InterpretContext };

--- a/libs/interpret/src/lib/MLIDashboard/context/InterpretContext.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/context/InterpretContext.tsx
@@ -1,15 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Cohort, JointDataset } from "@responsible-ai/core-ui";
+import {
+  Cohort,
+  IGlobalFeatureImportance,
+  JointDataset
+} from "@responsible-ai/core-ui";
 import React from "react";
 
 import { ITelemetryMessage } from "../Interfaces/ITelemetryMessage";
 
 export interface IInterpretContext {
   cohorts: Cohort[];
-  globalImportanceIntercept: number[];
-  globalImportance: number[][];
+  globalImportance?: IGlobalFeatureImportance;
   jointDataset: JointDataset;
   telemetryHook: (message: ITelemetryMessage) => void;
   requestPredictions:
@@ -26,8 +29,7 @@ export interface IInterpretContext {
 
 const interpretContext = React.createContext<IInterpretContext>({
   cohorts: [],
-  globalImportance: [],
-  globalImportanceIntercept: [],
+  globalImportance: undefined,
   jointDataset: {} as JointDataset,
   requestLocalFeatureExplanations: undefined,
   requestPredictions: undefined,

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -683,10 +683,6 @@ export class ModelAssessmentDashboard extends React.PureComponent<
                   <GlobalExplanationTab
                     jointDataset={this.state.jointDataset}
                     metadata={this.state.modelMetadata}
-                    globalImportance={this.state.globalImportance}
-                    isGlobalDerivedFromLocal={
-                      this.state.isGlobalImportanceDerivedFromLocal
-                    }
                     cohorts={this.state.cohorts.map(
                       (errorCohort) => errorCohort.cohort
                     )}


### PR DESCRIPTION
1. use global names for global feature importance
2. missingParametersPlaceholder styles are copied all over the places, I replace it by a dedicated component 
3. precompute global importance are transformed and copied in many places yet only used in one component.  Instead I use the raw data from context.
4. private field in react is totally wrong, should always use state.
5. having raw html tag "<br>" in string is a really bad practice, since tool tip support string array for line wrap we should use string array instead of raw tag.
