### PR TITLE
fix indexing issue on cohort shift

### DIFF
--- a/libs/core-ui/src/lib/Cohort/Cohort.ts
+++ b/libs/core-ui/src/lib/Cohort/Cohort.ts
@@ -72,8 +72,12 @@ export class Cohort {
       this.currentSortKey = columnName;
       this.currentSortReversed = false;
     }
+    if (reverse === undefined) {
+      reverse = false;
+    }
     if (this.currentSortReversed !== reverse) {
       this.filteredData.reverse();
+      this.currentSortReversed = true;
     }
   }
 


### PR DESCRIPTION
I noticed sometimes the indexes are not sorted in order on cohort shift in the local importances view, I realized this is actually similar to a previous bug but somehow the sort method I added is not working - apparently, it was not doing anything because the index column was still the same in this specific case (in a different workflow, the sort column changed in the aggregate importances/dataset views).  This PR forces the sort to happen.