### PR TITLE
reduce the lower-bound on the lightgbm dependency

### DIFF
--- a/erroranalysis/requirements.txt
+++ b/erroranalysis/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.17.2
 pandas>=0.25.1
 scipy>=1.4.1
 scikit-learn>=0.22.1
-lightgbm>=3.1.1
+lightgbm>=2.0.11

--- a/raitools/requirements.txt
+++ b/raitools/requirements.txt
@@ -2,6 +2,6 @@ numpy>=1.17.2
 pandas>=0.25.1
 scipy>=1.4.1
 scikit-learn>=0.22.1
-lightgbm>=2.2.3
+lightgbm>=2.0.11
 interpret-community>=0.17.0
 fairlearn>=0.4.6

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -5,5 +5,5 @@ rai-core-flask==0.2.1
 jinja2==2.11.1
 ipython==7.16.1
 scikit-learn>=0.22.1
-lightgbm>=3.1.1
+lightgbm>=2.0.11
 erroranalysis>=0.1.1


### PR DESCRIPTION
reduce lightgbm lower bound dependency to >=2.0.11, since raiwidgets, raitools and erroranalysis are all compatible with it