### PR TITLE
disable predict URL for simple EA widget case, which disables what if and ICE plots

### DIFF
--- a/apps/widget/src/app/ErrorAnalysis.tsx
+++ b/apps/widget/src/app/ErrorAnalysis.tsx
@@ -15,9 +15,11 @@ export class ErrorAnalysis extends React.Component {
     let requestDebugMLMethod = undefined;
     let requestImportancesMethod = undefined;
     if (config.baseUrl !== undefined) {
-      requestPredictionsMethod = async (data: any[]): Promise<any[]> => {
-        return callFlaskService(data, "/predict");
-      };
+      if (modelData.enablePredict) {
+        requestPredictionsMethod = async (data: any[]): Promise<any[]> => {
+          return callFlaskService(data, "/predict");
+        };
+      }
       requestMatrixMethod = async (data: any[]): Promise<any[]> => {
         return callFlaskService(data, "/matrix");
       };

--- a/raiwidgets/raiwidgets/dashboard.py
+++ b/raiwidgets/raiwidgets/dashboard.py
@@ -62,9 +62,9 @@ class Dashboard(object):
         self.id = uuid.uuid4().hex
 
         self.config = {
-            "dashboardType": dashboard_type,
-            "id": self.id,
-            "baseUrl": self._service.env.base_url,
+            'dashboardType': dashboard_type,
+            'id': self.id,
+            'baseUrl': self._service.env.base_url,
             'withCredentials': self._service.with_credentials
         }
         if add_local_url:

--- a/raiwidgets/raiwidgets/error_analysis_constants.py
+++ b/raiwidgets/raiwidgets/error_analysis_constants.py
@@ -8,3 +8,4 @@ class ErrorAnalysisDashboardInterface(object):
     """Dictionary properties shared between python and javascript object."""
     TREE_URL = "treeUrl"
     MATRIX_URL = "matrixUrl"
+    ENABLE_PREDICT = 'enablePredict'

--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -94,7 +94,6 @@ class ErrorAnalysisDashboard(Dashboard):
             explanation, model, dataset, true_y, classes,
             features, locale, categorical_features,
             true_y_dataset, pred_y)
-
         super(ErrorAnalysisDashboard, self).__init__(
             dashboard_type="ErrorAnalysis",
             model_data=self.input.dashboard_input,


### PR DESCRIPTION
For the simple ErrorAnalysis widget that only uses the predictions and not the model or explanations, the widget was still trying to show ICE plots and what if.  This fix disables those views by setting the prediction URL to be undefined in the UX using the "enablePredict" field.