### PR TITLE
make save and load methods private on each of the managers

### DIFF
--- a/raitools/raitools/_managers/base_manager.py
+++ b/raitools/raitools/_managers/base_manager.py
@@ -47,7 +47,7 @@ class BaseManager(ABC):
         """
 
     @abstractmethod
-    def save(self, path):
+    def _save(self, path):
         """Abstract method to save the manager.
 
         :param path: The directory path to save the manager to.
@@ -56,7 +56,7 @@ class BaseManager(ABC):
 
     @staticmethod
     @abstractmethod
-    def load(path, rai_analyzer):
+    def _load(path, rai_analyzer):
         """Static method to load the manager.
 
         :param path: The directory path to load the manager from.

--- a/raitools/raitools/_managers/causal_manager.py
+++ b/raitools/raitools/_managers/causal_manager.py
@@ -32,9 +32,9 @@ class CausalManager(BaseManager):
         """
         return ManagerNames.CAUSAL
 
-    def save(self, path):
+    def _save(self, path):
         pass
 
     @staticmethod
-    def load(path, rai_analyzer):
+    def _load(path, rai_analyzer):
         pass

--- a/raitools/raitools/_managers/counterfactual_manager.py
+++ b/raitools/raitools/_managers/counterfactual_manager.py
@@ -240,9 +240,9 @@ class CounterfactualManager(BaseManager):
         """
         return ManagerNames.COUNTERFACTUAL
 
-    def save(self, path):
+    def _save(self, path):
         pass
 
     @staticmethod
-    def load(path, rai_analyzer):
+    def _load(path, rai_analyzer):
         pass

--- a/raitools/raitools/_managers/error_analysis_manager.py
+++ b/raitools/raitools/_managers/error_analysis_manager.py
@@ -34,9 +34,9 @@ class ErrorAnalysisManager(BaseManager):
         """
         return ManagerNames.ERROR_ANALYSIS
 
-    def save(self, path):
+    def _save(self, path):
         pass
 
     @staticmethod
-    def load(path, rai_analyzer):
+    def _load(path, rai_analyzer):
         pass

--- a/raitools/raitools/_managers/explainer_manager.py
+++ b/raitools/raitools/_managers/explainer_manager.py
@@ -161,7 +161,7 @@ class ExplainerManager(BaseManager):
         """
         return ManagerNames.EXPLAINER
 
-    def save(self, path):
+    def _save(self, path):
         """Save the ExplainerManager to the given path.
 
         :param path: The directory path to save the ExplainerManager to.
@@ -178,7 +178,7 @@ class ExplainerManager(BaseManager):
             json.dump(meta, file)
 
     @staticmethod
-    def load(path, rai_analyzer):
+    def _load(path, rai_analyzer):
         """Load the ExplainerManager from the given path.
 
         :param path: The directory path to load the ExplainerManager from.

--- a/raitools/raitools/_managers/fairness_manager.py
+++ b/raitools/raitools/_managers/fairness_manager.py
@@ -34,9 +34,9 @@ class FairnessManager(BaseManager):
         """
         return ManagerNames.FAIRNESS
 
-    def save(self, path):
+    def _save(self, path):
         pass
 
     @staticmethod
-    def load(path, rai_analyzer):
+    def _load(path, rai_analyzer):
         pass

--- a/raitools/raitools/raianalyzer/rai_analyzer.py
+++ b/raitools/raitools/raianalyzer/rai_analyzer.py
@@ -179,7 +179,7 @@ class RAIAnalyzer(object):
         top_dir = Path(path)
         # save each of the individual managers
         for manager in self._managers:
-            manager.save(top_dir / manager.name)
+            manager._save(top_dir / manager.name)
         # save current state
         dtypes = self.train.dtypes.astype(str).to_dict()
         self._write_to_file(top_dir / (_TRAIN + _DTYPES),
@@ -254,26 +254,26 @@ class RAIAnalyzer(object):
         managers = []
         cm_name = '_' + ManagerNames.CAUSAL + '_manager'
         causal_dir = top_dir / ManagerNames.CAUSAL
-        causal_manager = CausalManager.load(causal_dir, inst)
+        causal_manager = CausalManager._load(causal_dir, inst)
         inst.__dict__[cm_name] = causal_manager
         managers.append(causal_manager)
         cfm_name = '_' + ManagerNames.COUNTERFACTUAL + '_manager'
         cf_dir = top_dir / ManagerNames.COUNTERFACTUAL
-        counterfactual_manager = CounterfactualManager.load(cf_dir, inst)
+        counterfactual_manager = CounterfactualManager._load(cf_dir, inst)
         inst.__dict__[cfm_name] = counterfactual_manager
         managers.append(counterfactual_manager)
         eam_name = '_' + ManagerNames.ERROR_ANALYSIS + '_manager'
         ea_dir = top_dir / ManagerNames.ERROR_ANALYSIS
-        error_analysis_manager = ErrorAnalysisManager.load(ea_dir, inst)
+        error_analysis_manager = ErrorAnalysisManager._load(ea_dir, inst)
         inst.__dict__[eam_name] = error_analysis_manager
         exm_name = '_' + ManagerNames.EXPLAINER + '_manager'
         exp_dir = top_dir / ManagerNames.EXPLAINER
-        explainer_manager = ExplainerManager.load(exp_dir, inst)
+        explainer_manager = ExplainerManager._load(exp_dir, inst)
         inst.__dict__[exm_name] = explainer_manager
         managers.append(explainer_manager)
         fm_name = '_' + ManagerNames.FAIRNESS + '_manager'
         fairness_dir = top_dir / ManagerNames.FAIRNESS
-        fairness_manager = FairnessManager.load(fairness_dir, inst)
+        fairness_manager = FairnessManager._load(fairness_dir, inst)
         inst.__dict__[fm_name] = fairness_manager
         managers.append(fairness_manager)
         inst.__dict__['_' + _MANAGERS] = managers


### PR DESCRIPTION
Add "_" to the save and load methods on each of the individual managers.  Only the top-level RAIAnalyzer save/load APIs will be public.