### PR TITLE
added initial error analysis manager implementation

### DIFF
--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -10,6 +10,7 @@ from sklearn.feature_selection import mutual_info_classif
 from erroranalysis._internal.matrix_filter import compute_json_matrix
 from erroranalysis._internal.surrogate_error_tree import (
     compute_json_error_tree)
+from erroranalysis._internal.error_report import ErrorReport
 
 
 class BaseAnalyzer(ABC):
@@ -75,9 +76,34 @@ class BaseAnalyzer(ABC):
     def compute_matrix(self, features, filters, composite_filters):
         return compute_json_matrix(self, features, filters, composite_filters)
 
-    def compute_error_tree(self, features, filters, composite_filters):
-        return compute_json_error_tree(self, features, filters,
-                                       composite_filters)
+    def compute_error_tree(self,
+                           features,
+                           filters,
+                           composite_filters,
+                           max_depth=None,
+                           num_leaves=None):
+        return compute_json_error_tree(self,
+                                       features,
+                                       filters,
+                                       composite_filters,
+                                       max_depth=max_depth,
+                                       num_leaves=num_leaves)
+
+    def create_error_report(self,
+                            filter_features,
+                            max_depth,
+                            num_leaves):
+        json_tree = self.compute_error_tree(self.feature_names,
+                                            None,
+                                            None,
+                                            max_depth=max_depth,
+                                            num_leaves=num_leaves)
+        json_matrix = None
+        if filter_features is not None:
+            json_matrix = self.compute_matrix(filter_features,
+                                              None,
+                                              None)
+        return ErrorReport(json_tree, json_matrix)
 
     def compute_importances(self):
         input_data = self.dataset

--- a/erroranalysis/erroranalysis/_internal/error_report.py
+++ b/erroranalysis/erroranalysis/_internal/error_report.py
@@ -1,0 +1,116 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import json
+
+_ErrorReportVersion = '1.0'
+_AllVersions = [_ErrorReportVersion]
+
+
+def json_converter(obj):
+    """Helper function to convert ErrorReport object to json.
+
+    :param obj: Object to convert to json.
+    :type obj: object
+    :return: The converted json.
+    :rtype: dict
+    """
+    if isinstance(obj, ErrorReport):
+        rdict = obj.__dict__
+        return rdict
+    try:
+        return obj.to_json()
+    except AttributeError:
+        return obj.__dict__
+
+
+def as_error_report(json_dict):
+    """Helper function to convert json to an ErrorReport object.
+
+    :param json_dict: The json to convert.
+    :type json_dict: dict
+    :return: The converted ErrorReport.
+    :rtype: ErrorReport
+    """
+    if 'metadata' in json_dict:
+        version = json_dict['metadata'].get('version')
+        if version is None:
+            raise ValueError("No version field in the json input")
+        elif version not in _AllVersions:
+            raise ValueError(
+                "Unknown version in read ErrorReport: {}".format(version))
+        return ErrorReport(json_dict["json_tree"], json_dict["json_matrix"])
+    else:
+        return json_dict
+
+
+class ErrorReport(object):
+
+    """Defines the ErrorReport, which contains the tree and matrix filter.
+
+    :param json_tree: The json representation of the tree.
+    :type json_tree: dict
+    :param json_matrix: The json representation of the matrix filter.
+    :type json_matrix: dict
+    """
+
+    def __init__(self, json_tree, json_matrix):
+        """Defines the ErrorReport, which contains the tree and matrix filter.
+
+        :param json_tree: The json representation of the tree.
+        :type json_tree: dict
+        :param json_matrix: The json representation of the matrix filter.
+        :type json_matrix: dict
+        """
+        self._json_tree = json_tree
+        self._json_matrix = json_matrix
+        self._metadata = {'version': _ErrorReportVersion}
+
+    @property
+    def __dict__(self):
+        """Returns the dictionary representation of the Error Report.
+
+        The dictionary contains the json representation of the tree,
+        the matrix filter and any Error Report metadata.
+
+        :return: The dictionary representation of the Error Report.
+        :rtype: dict
+        """
+        return {'json_tree': self._json_tree,
+                'json_matrix': self._json_matrix,
+                'metadata': self._metadata}
+
+    @property
+    def json_tree(self):
+        """Returns the json representation of the tree.
+
+        :return: The json representation of the tree.
+        :rtype: dict
+        """
+        return self._json_tree
+
+    @property
+    def json_matrix(self):
+        """Returns the json representation of the matrix filter.
+
+        :return: The json representation of the matrix filter.
+        :rtype: dict
+        """
+        return self._json_matrix
+
+    def to_json(self):
+        """Serialize ErrorReport object to json.
+
+        :return: The string json representation of the ErrorReport.
+        :rtype: str
+        """
+        return json.dumps(self, default=json_converter, indent=2)
+
+    @staticmethod
+    def from_json(json_str):
+        """Deserialize json string to an ErrorReport object.
+
+        :return: The deserialized ErrorReport.
+        :rtype: ErrorReport
+        """
+        return json.loads(json_str, object_hook=as_error_report)

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -18,6 +18,8 @@ from erroranalysis._internal.constants import (PRED_Y,
                                                METHOD_INCLUDES)
 
 MODEL = 'model'
+DEFAULT_MAX_DEPTH = 3
+DEFAULT_NUM_LEAVES = 31
 
 
 class TreeSide(str, Enum):
@@ -34,10 +36,19 @@ class TreeSide(str, Enum):
     UNKNOWN = 'unknown'
 
 
-def compute_json_error_tree(analyzer, features, filters,
-                            composite_filters):
+def compute_json_error_tree(analyzer,
+                            features,
+                            filters,
+                            composite_filters,
+                            max_depth=DEFAULT_MAX_DEPTH,
+                            num_leaves=DEFAULT_NUM_LEAVES):
     # Fit a surrogate model on errors
-    surrogate = LGBMClassifier(n_estimators=1, max_depth=3)
+    if max_depth is None:
+        max_depth = DEFAULT_MAX_DEPTH
+    if num_leaves is None:
+        num_leaves = DEFAULT_NUM_LEAVES
+    surrogate = LGBMClassifier(n_estimators=1, max_depth=max_depth,
+                               num_leaves=num_leaves)
     is_model_analyzer = hasattr(analyzer, MODEL)
     if is_model_analyzer:
         filtered_df = filter_from_cohort(analyzer.dataset,

--- a/raitools/raitools/_config/base_config.py
+++ b/raitools/raitools/_config/base_config.py
@@ -1,0 +1,21 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Base configuration class."""
+
+from abc import ABC, abstractmethod
+
+
+class BaseConfig(ABC):
+    def __init__(self):
+        self.is_computed = False
+
+    @abstractmethod
+    def __eq__(self, other_ea_config):
+        pass
+
+    def is_duplicate(self, config_list):
+        for config in config_list:
+            if self == config:
+                return True
+        return False

--- a/raitools/raitools/_managers/counterfactual_manager.py
+++ b/raitools/raitools/_managers/counterfactual_manager.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from raitools._internal.constants import ManagerNames
 from raitools._managers.base_manager import BaseManager
+from raitools._config.base_config import BaseConfig
 from raitools.raianalyzer.constants import ModelTask
 from raitools.exceptions import (
     UserConfigValidationException, DuplicateCounterfactualConfigException
@@ -22,11 +23,12 @@ class CounterfactualConstants:
     RANDOM = 'random'
 
 
-class CounterfactualConfig:
+class CounterfactualConfig(BaseConfig):
     def __init__(self, method, continuous_features, total_CFs,
                  desired_class=CounterfactualConstants.OPPOSITE,
                  desired_range=None, permitted_range=None,
                  features_to_vary=None):
+        super(CounterfactualConfig, self).__init__()
         self.method = method
         self.continuous_features = continuous_features
         self.total_CFs = total_CFs
@@ -34,7 +36,6 @@ class CounterfactualConfig:
         self.desired_class = desired_class
         self.permitted_range = permitted_range
         self.features_to_vary = features_to_vary
-        self.is_computed = False
         self.counterfactual_obj = None
         self.has_computation_failed = False
         self.failure_reason = None
@@ -122,13 +123,10 @@ class CounterfactualManager(BaseManager):
                     'The desired_range should not be None'
                     ' for regression scenarios.')
 
-        duplicate_counterfactual_config_found = False
-        for counterfactual_config in self._counterfactual_config_list:
-            if counterfactual_config == new_counterfactual_config:
-                duplicate_counterfactual_config_found = True
-                break
+        is_duplicate = new_counterfactual_config.is_duplicate(
+            self._counterfactual_config_list)
 
-        if duplicate_counterfactual_config_found:
+        if is_duplicate:
             raise DuplicateCounterfactualConfigException(
                 'Duplicate counterfactual configuration detected.')
         else:

--- a/raitools/raitools/_managers/error_analysis_manager.py
+++ b/raitools/raitools/_managers/error_analysis_manager.py
@@ -5,22 +5,139 @@
 
 from raitools._internal.constants import ManagerNames
 from raitools._managers.base_manager import BaseManager
+from raitools._config.base_config import BaseConfig
+from erroranalysis._internal.error_analyzer import ModelAnalyzer
+
+
+class ErrorAnalysisConfig(BaseConfig):
+
+    """Defines the ErrorAnalysisConfig, specifying the parameters to run.
+
+    :param max_depth: The maximum depth of the tree.
+    :type max_depth: int
+    :param num_leaves: The number of leaves in the tree.
+    :type num_leaves: int
+    :param filter_features: One or two features to use for the
+        matrix filter.
+    :type filter_features: list
+    """
+
+    def __init__(self, max_depth, num_leaves, filter_features):
+        """Defines the ErrorAnalysisConfig, specifying the parameters to run.
+
+        :param max_depth: The maximum depth of the tree.
+        :type max_depth: int
+        :param num_leaves: The number of leaves in the tree.
+        :type num_leaves: int
+        :param filter_features: One or two features to use for the
+            matrix filter.
+        :type filter_features: list
+        """
+        super(ErrorAnalysisConfig, self).__init__()
+        self.max_depth = max_depth
+        self.num_leaves = num_leaves
+        self.filter_features = filter_features
+
+    def __eq__(self, other_ea_config):
+        """Returns true if this config is equal to the given config.
+
+        :return: True if the given config is equal to the current config.
+        :rtype: boolean
+        """
+        return (
+            self.max_depth == other_ea_config.max_depth and
+            self.num_leaves == other_ea_config.num_leaves and
+            self.filter_features == other_ea_config.filter_features
+        )
 
 
 class ErrorAnalysisManager(BaseManager):
-    def __init__(self):
-        pass
 
-    def add(self):
-        raise NotImplementedError(
-            "Add not implemented for ErrorAnalysisManager")
+    """Defines the ErrorAnalysisManager for discovering errors in a model.
+
+    :param model: The model to analyze errors on.
+        A model that implements sklearn.predict or sklearn.predict_proba
+        or function that accepts a 2d ndarray.
+    :type model: object
+    :param train: The training dataset including the label column.
+    :type train: pandas.DataFrame
+    :param target_column: The name of the label column.
+    :type target_column: str
+    """
+
+    def __init__(self, model, train, target_column):
+        """Defines the ErrorAnalysisManager for discovering errors in a model.
+
+        :param model: The model to analyze errors on.
+            A model that implements sklearn.predict or sklearn.predict_proba
+            or function that accepts a 2d ndarray.
+        :type model: object
+        :param train: The training dataset including the label column.
+        :type train: pandas.DataFrame
+        :param target_column: The name of the label column.
+        :type target_column: str
+        """
+        self._model = model
+        self._y_train = train[target_column]
+        self._train = train.drop(columns=[target_column])
+        self._feature_names = list(self._train.columns)
+        # TODO: Add categorical features support
+        self._categorical_features = None
+        self._ea_config_list = []
+        self._ea_report_list = []
+
+    def add(self, max_depth=3, num_leaves=31, filter_features=None):
+        """Add an error analyzer to be computed later.
+
+        :param max_depth: The maximum depth of the tree.
+        :type max_depth: int
+        :param num_leaves: The number of leaves in the tree.
+        :type num_leaves: int
+        :param filter_features: One or two features to use for the
+            matrix filter.
+        :type filter_features: list
+        """
+        ea_config = ErrorAnalysisConfig(
+            max_depth=max_depth,
+            num_leaves=num_leaves,
+            filter_features=filter_features)
+        is_duplicate = ea_config.is_duplicate(
+            self._ea_config_list)
+
+        if is_duplicate:
+            raise ValueError(
+                "Duplicate config specified, config already added")
+        else:
+            self._ea_config_list.append(ea_config)
 
     def compute(self):
-        pass
+        """Creates an ErrorReport by running the error analyzer on the model.
+        """
+        for config in self._ea_config_list:
+            if config.is_computed:
+                continue
+            config.is_computed = True
+            analyzer = ModelAnalyzer(self._model,
+                                     self._train,
+                                     self._y_train,
+                                     self._feature_names,
+                                     self._categorical_features)
+            max_depth = config.max_depth
+            num_leaves = config.num_leaves
+            report = analyzer.create_error_report(config.filter_features,
+                                                  max_depth=max_depth,
+                                                  num_leaves=num_leaves)
+            self._ea_report_list.append(report)
 
     def get(self):
-        raise NotImplementedError(
-            "Get not implemented for ErrorAnalysisManager")
+        """Get the computed error reports.
+
+        Must be called after add and compute methods.
+
+        :return: The computed error reports.
+        :rtype: list[erroranalysis._internal.error_report.ErrorReport]
+        """
+        return self._ea_report_list
 
     def list(self):
         pass

--- a/raitools/raitools/_managers/explainer_manager.py
+++ b/raitools/raitools/_managers/explainer_manager.py
@@ -168,6 +168,7 @@ class ExplainerManager(BaseManager):
         :type path: str
         """
         top_dir = Path(path)
+        top_dir.mkdir(parents=True, exist_ok=True)
         # save the explanation
         if self._explanation:
             save_explanation(self._explanation,

--- a/raitools/raitools/raianalyzer/rai_analyzer.py
+++ b/raitools/raitools/raianalyzer/rai_analyzer.py
@@ -87,7 +87,9 @@ class RAIAnalyzer(object):
         self._counterfactual_manager = CounterfactualManager(
             model=model, train=train, test=test,
             target_column=target_column, task_type=task_type)
-        self._error_analysis_manager = ErrorAnalysisManager()
+        self._error_analysis_manager = ErrorAnalysisManager(model,
+                                                            train,
+                                                            target_column)
         self._classes = train[target_column].unique()
         self._explainer_manager = ExplainerManager(model, train, test,
                                                    target_column,

--- a/raitools/tests/counterfactual_manager_validator.py
+++ b/raitools/tests/counterfactual_manager_validator.py
@@ -2,77 +2,14 @@
 # Licensed under the MIT License.
 
 import pytest
-import pandas as pd
-from common_utils import (create_iris_data, create_cancer_data,
-                          create_models_classification,
-                          create_models_regression,
-                          create_boston_data)
-from raitools import RAIAnalyzer, ModelTask
+from raitools import ModelTask
 from raitools.exceptions import (
     DuplicateCounterfactualConfigException, UserConfigValidationException
 )
 
 
-LABELS = "labels"
-
-
-class TestRAIAnalyzerCounterfactualMulticlass(object):
-
-    def test_raianalyzer_iris(self):
-        x_train, x_test, y_train, y_test, feature_names, classes = \
-            create_iris_data()
-        x_train = pd.DataFrame(x_train, columns=feature_names)
-        x_test = pd.DataFrame(x_test, columns=feature_names)
-        models = create_models_classification(x_train, y_train)
-        x_train[LABELS] = y_train
-        x_test[LABELS] = y_test
-
-        for model in models:
-            run_counterfactual_rai_analyzer(model, x_train, x_test, LABELS,
-                                            classes, desired_class=0)
-
-
-class TestRAIAnalyzerCounterfactualBinary(object):
-
-    def test_raianalyzer_cancer(self):
-        x_train, x_test, y_train, y_test, feature_names, classes = \
-            create_cancer_data()
-        x_train = pd.DataFrame(x_train, columns=feature_names)
-        x_test = pd.DataFrame(x_test, columns=feature_names)
-        models = create_models_classification(x_train, y_train)
-        x_train[LABELS] = y_train
-        x_test[LABELS] = y_test
-
-        for model in models:
-            run_counterfactual_rai_analyzer(model, x_train, x_test, LABELS,
-                                            classes, desired_class="opposite")
-
-
-class TestRAIAnalyzerCounterfactualRegression(object):
-
-    def test_raianalyzer_boston(self):
-        x_train, x_test, y_train, y_test, feature_names = \
-            create_boston_data()
-        x_train = pd.DataFrame(x_train, columns=feature_names)
-        x_test = pd.DataFrame(x_test, columns=feature_names)
-        models = create_models_regression(x_train, y_train)
-        x_train[LABELS] = y_train
-        x_test[LABELS] = y_test
-
-        for model in models:
-            run_counterfactual_rai_analyzer(model, x_train, x_test, LABELS,
-                                            desired_range=[10, 20])
-
-
-def run_counterfactual_rai_analyzer(model, x_train, x_test, target_column,
-                                    classes=None, desired_class=None,
-                                    desired_range=None):
-    if classes is not None:
-        task_type = ModelTask.CLASSIFICATION
-    else:
-        task_type = ModelTask.REGRESSION
-    cf_analyzer = RAIAnalyzer(model, x_train, x_test[0:1], target_column,
-                              task_type=task_type)
+def validate_counterfactual(cf_analyzer, x_train, target_column,
+                            desired_class=None, desired_range=None):
     continuous_features = list(set(x_train.columns) - set([target_column]))
 
     # Add the first configuration
@@ -117,6 +54,7 @@ def run_counterfactual_rai_analyzer(model, x_train, x_test, target_column,
     assert len(cf_analyzer.counterfactual.get()) == 2
     assert len(cf_analyzer.counterfactual.get(failed_to_compute=True)) == 1
 
+    task_type = cf_analyzer.task_type
     if task_type == ModelTask.REGRESSION:
         with pytest.raises(UserConfigValidationException):
             cf_analyzer.counterfactual.add(

--- a/raitools/tests/error_analysis_validator.py
+++ b/raitools/tests/error_analysis_validator.py
@@ -1,0 +1,62 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+from erroranalysis._internal.matrix_filter import (
+    CATEGORY1, CATEGORY2, COUNT, FALSE_COUNT, MATRIX, VALUES)
+
+SIZE = 'size'
+PARENTID = 'parentId'
+ERROR = 'error'
+ID = 'id'
+
+
+def validate_error_analysis(rai_analyzer):
+    rai_analyzer.error_analysis.add()
+    rai_analyzer.error_analysis.compute()
+    reports = rai_analyzer.error_analysis.get()
+    assert isinstance(reports, list)
+    assert len(reports) == 1
+    report = reports[0]
+    json_matrix = report.json_matrix
+
+    ea_x_train = rai_analyzer.error_analysis._train
+    ea_y_train = rai_analyzer.error_analysis._y_train
+
+    expected_count = len(ea_x_train)
+    if json_matrix is not None:
+        predictions = rai_analyzer.model.predict(ea_x_train)
+        expected_false_count = sum(predictions != ea_y_train)
+        validate_matrix(json_matrix, expected_count, expected_false_count)
+
+    json_tree = report.json_tree
+    validate_tree(json_tree, expected_count)
+
+
+def validate_matrix(json_matrix, exp_total_count, exp_total_false_count):
+    assert MATRIX in json_matrix
+    assert CATEGORY1 in json_matrix
+    assert CATEGORY2 in json_matrix
+    num_cat1 = len(json_matrix[CATEGORY1][VALUES])
+    num_cat2 = len(json_matrix[CATEGORY2][VALUES])
+    assert len(json_matrix[MATRIX]) == num_cat1
+    assert len(json_matrix[MATRIX][0]) == num_cat2
+    # take sum of count, false count
+    total_count = 0
+    total_false_count = 0
+    for i in range(num_cat1):
+        for j in range(num_cat2):
+            total_count += json_matrix[MATRIX][i][j][COUNT]
+            total_false_count += json_matrix[MATRIX][i][j][FALSE_COUNT]
+    assert exp_total_count == total_count
+    assert exp_total_false_count == total_false_count
+
+
+def validate_tree(json_tree, expected_count):
+    assert json_tree is not None
+    assert len(json_tree) > 0
+    assert ERROR in json_tree[0]
+    assert ID in json_tree[0]
+    assert PARENTID in json_tree[0]
+    assert json_tree[0][PARENTID] is None
+    assert SIZE in json_tree[0]
+    assert json_tree[0][SIZE] == expected_count

--- a/raitools/tests/explainer_manager_validator.py
+++ b/raitools/tests/explainer_manager_validator.py
@@ -1,0 +1,36 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import pytest
+from raitools._internal.constants import ManagerNames, ListProperties
+from raitools import ModelTask
+
+LIGHTGBM_METHOD = 'mimic.lightgbm'
+
+
+def setup_explainer(rai_analyzer, add_explainer=True):
+    if add_explainer:
+        rai_analyzer.explainer.add()
+        # Validate calling add multiple times prints a warning
+        with pytest.warns(UserWarning):
+            rai_analyzer.explainer.add()
+    rai_analyzer.explainer.compute()
+
+
+def validate_explainer(rai_analyzer, x_train, x_test, classes):
+    explanations = rai_analyzer.explainer.get()
+    assert isinstance(explanations, list)
+    assert len(explanations) == 1
+    explanation = explanations[0]
+    assert len(explanation.local_importance_values) == len(classes)
+    assert len(explanation.local_importance_values[0]) == len(x_test)
+    num_cols = len(x_train.columns) - 1
+    assert len(explanation.local_importance_values[0][0]) == num_cols
+    properties = rai_analyzer.explainer.list()
+    assert properties[ListProperties.MANAGER_TYPE] == ManagerNames.EXPLAINER
+    assert 'id' in properties
+    assert properties['method'] == LIGHTGBM_METHOD
+    assert properties['model_task'] == ModelTask.CLASSIFICATION
+    assert properties['model_type'] is None
+    assert properties['is_raw'] is False
+    assert properties['is_engineered'] is False

--- a/raitools/tests/test_rai_analyzer.py
+++ b/raitools/tests/test_rai_analyzer.py
@@ -6,19 +6,30 @@ import pandas as pd
 import numpy as np
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from common_utils import (create_iris_data, create_cancer_data,
+from common_utils import (create_boston_data,
+                          create_cancer_data,
+                          create_iris_data,
                           create_binary_classification_dataset,
-                          create_models_classification)
+                          create_models_classification,
+                          create_models_regression)
 from raitools import RAIAnalyzer, ModelTask
-from raitools._internal.constants import ManagerNames, ListProperties
+from raitools._internal.constants import ManagerNames
+from explainer_manager_validator import (setup_explainer,
+                                         validate_explainer)
+from counterfactual_manager_validator import validate_counterfactual
+from error_analysis_validator import validate_error_analysis
 
 LABELS = "labels"
-LIGHTGBM_METHOD = 'mimic.lightgbm'
+DESIRED_CLASS = 'desired_class'
+DESIRED_RANGE = 'desired_range'
 
 
 class TestRAIAnalyzer(object):
 
-    def test_rai_analyzer_iris(self):
+    @pytest.mark.parametrize('manager_type', [ManagerNames.ERROR_ANALYSIS,
+                                              ManagerNames.COUNTERFACTUAL,
+                                              ManagerNames.EXPLAINER])
+    def test_rai_analyzer_iris(self, manager_type):
         x_train, x_test, y_train, y_test, feature_names, classes = \
             create_iris_data()
         x_train = pd.DataFrame(x_train, columns=feature_names)
@@ -26,11 +37,15 @@ class TestRAIAnalyzer(object):
         models = create_models_classification(x_train, y_train)
         x_train[LABELS] = y_train
         x_test[LABELS] = y_test
+        manager_args = {DESIRED_CLASS: 0}
 
         for model in models:
-            run_rai_analyzer(model, x_train, x_test, LABELS, classes)
+            run_rai_analyzer(model, x_train, x_test, LABELS,
+                             manager_type, manager_args, classes)
 
-    def test_rai_analyzer_cancer(self):
+    @pytest.mark.parametrize('manager_type', [ManagerNames.COUNTERFACTUAL,
+                                              ManagerNames.EXPLAINER])
+    def test_rai_analyzer_cancer(self, manager_type):
         x_train, x_test, y_train, y_test, feature_names, classes = \
             create_cancer_data()
         x_train = pd.DataFrame(x_train, columns=feature_names)
@@ -38,11 +53,14 @@ class TestRAIAnalyzer(object):
         models = create_models_classification(x_train, y_train)
         x_train[LABELS] = y_train
         x_test[LABELS] = y_test
+        manager_args = {DESIRED_CLASS: 'opposite'}
 
         for model in models:
-            run_rai_analyzer(model, x_train, x_test, LABELS, classes)
+            run_rai_analyzer(model, x_train, x_test, LABELS,
+                             manager_type, manager_args, classes)
 
-    def test_rai_analyzer_binary(self):
+    @pytest.mark.parametrize('manager_type', [ManagerNames.EXPLAINER])
+    def test_rai_analyzer_binary(self, manager_type):
         x_train, y_train, x_test, y_test, classes = \
             create_binary_classification_dataset()
         x_train = pd.DataFrame(x_train)
@@ -50,33 +68,69 @@ class TestRAIAnalyzer(object):
         models = create_models_classification(x_train, y_train)
         x_train[LABELS] = y_train
         x_test[LABELS] = y_test
+        manager_args = None
 
         for model in models:
-            run_rai_analyzer(model, x_train, x_test, LABELS, classes)
+            run_rai_analyzer(model, x_train, x_test, LABELS,
+                             manager_type, manager_args,
+                             classes=classes)
+
+    @pytest.mark.parametrize('manager_type', [ManagerNames.COUNTERFACTUAL])
+    def test_raianalyzer_boston(self, manager_type):
+        x_train, x_test, y_train, y_test, feature_names = \
+            create_boston_data()
+        x_train = pd.DataFrame(x_train, columns=feature_names)
+        x_test = pd.DataFrame(x_test, columns=feature_names)
+        models = create_models_regression(x_train, y_train)
+        x_train[LABELS] = y_train
+        x_test[LABELS] = y_test
+        manager_args = {DESIRED_RANGE: [10, 20]}
+
+        for model in models:
+            run_rai_analyzer(model, x_train, x_test, LABELS,
+                             manager_type, manager_args)
 
 
-def run_rai_analyzer(model, x_train, x_test, target_column, classes):
-    task_type = ModelTask.CLASSIFICATION
+def run_rai_analyzer(model, x_train, x_test, target_column,
+                     manager_type, manager_args=None, classes=None):
+    if classes is not None:
+        task_type = ModelTask.CLASSIFICATION
+    else:
+        task_type = ModelTask.REGRESSION
+    if manager_type == ManagerNames.COUNTERFACTUAL:
+        x_test = x_test[0:1]
     rai_analyzer = RAIAnalyzer(model, x_train, x_test, target_column,
                                task_type=task_type)
-    rai_analyzer.explainer.add()
-    # Validate calling add multiple times prints a warning
-    with pytest.warns(UserWarning):
-        rai_analyzer.explainer.add()
-    rai_analyzer.explainer.compute()
+    if manager_type == ManagerNames.EXPLAINER:
+        setup_explainer(rai_analyzer)
     validate_rai_analyzer(rai_analyzer, x_train, x_test, target_column,
                           task_type)
-    validate_explainer(rai_analyzer, x_train, x_test, classes)
+    if manager_type == ManagerNames.EXPLAINER:
+        validate_explainer(rai_analyzer, x_train, x_test, classes)
+    if manager_type == ManagerNames.COUNTERFACTUAL:
+        desired_range = None
+        desired_class = None
+        if manager_args is not None:
+            if DESIRED_CLASS in manager_args:
+                desired_class = manager_args[DESIRED_CLASS]
+            if DESIRED_RANGE in manager_args:
+                desired_range = manager_args[DESIRED_RANGE]
+        validate_counterfactual(rai_analyzer, x_train, target_column,
+                                desired_class, desired_range)
+    if manager_type == ManagerNames.ERROR_ANALYSIS:
+        validate_error_analysis(rai_analyzer)
     with TemporaryDirectory() as tempdir:
         path = Path(tempdir) / 'explanation'
         # save the rai_analyzer
         rai_analyzer.save(path)
         # load the rai_analyzer
         rai_analyzer = RAIAnalyzer.load(path)
-        rai_analyzer.explainer.compute()
-        validate_rai_analyzer(rai_analyzer, x_train, x_test, target_column,
-                              task_type)
-        validate_explainer(rai_analyzer, x_train, x_test, classes)
+        if manager_type == ManagerNames.EXPLAINER:
+            setup_explainer(rai_analyzer)
+        validate_rai_analyzer(rai_analyzer, x_train, x_test,
+                              target_column, task_type)
+        if manager_type == ManagerNames.EXPLAINER:
+            validate_explainer(rai_analyzer, x_train, x_test, classes)
 
 
 def validate_rai_analyzer(rai_analyzer, x_train, x_test, target_column,
@@ -87,22 +141,3 @@ def validate_rai_analyzer(rai_analyzer, x_train, x_test, target_column,
     assert rai_analyzer.task_type == task_type
     np.testing.assert_array_equal(rai_analyzer._classes,
                                   x_train[target_column].unique())
-
-
-def validate_explainer(rai_analyzer, x_train, x_test, classes):
-    explanations = rai_analyzer.explainer.get()
-    assert isinstance(explanations, list)
-    assert len(explanations) == 1
-    explanation = explanations[0]
-    assert len(explanation.local_importance_values) == len(classes)
-    assert len(explanation.local_importance_values[0]) == len(x_test)
-    num_cols = len(x_train.columns) - 1
-    assert len(explanation.local_importance_values[0][0]) == num_cols
-    properties = rai_analyzer.explainer.list()
-    assert properties[ListProperties.MANAGER_TYPE] == ManagerNames.EXPLAINER
-    assert 'id' in properties
-    assert properties['method'] == LIGHTGBM_METHOD
-    assert properties['model_task'] == ModelTask.CLASSIFICATION
-    assert properties['model_type'] is None
-    assert properties['is_raw'] is False
-    assert properties['is_engineered'] is False


### PR DESCRIPTION
- added error analysis manager implementation (except for save/load/list currently)
- refactored tests between counterfactual/error analysis/explanations to be structured in more similar way, reducing duplicate code

note: tests will fail until I get an initial review and publish the error analysis package to pypi once the code is ready
update: nevermind, it looks like all tests are passing because raitools tests are not running in CI yet anyway