### PR TITLE
adding save, load and list to error analysis manager

### DIFF
--- a/raitools/raitools/_internal/constants.py
+++ b/raitools/raitools/_internal/constants.py
@@ -4,7 +4,7 @@
 """Defines common private constants."""
 
 
-class ManagerNames(str):
+class ManagerNames(object):
     """Provide the manager names."""
 
     CAUSAL = 'causal'
@@ -13,20 +13,20 @@ class ManagerNames(str):
     EXPLAINER = 'explainer'
 
 
-class Metadata(str):
+class Metadata(object):
     """Provide constants for metadata and saved files."""
 
     META_JSON = 'meta.json'
     MODEL = 'model'
 
 
-class ListProperties(str):
+class ListProperties(object):
     """Provide constants for listing manager properties."""
 
     MANAGER_TYPE = 'manager_type'
 
 
-class ExplainerManagerKeys(str):
+class ExplainerManagerKeys(object):
     """Provide constants for ExplainerManager key properties."""
     ID = 'id'
     IS_COMPUTED = 'is_computed'
@@ -35,3 +35,12 @@ class ExplainerManagerKeys(str):
     METHOD = 'method'
     MODEL_TASK = 'model_task'
     MODEL_TYPE = 'model_type'
+
+
+class ErrorAnalysisManagerKeys(object):
+    """Provide constants for ErrorAnalysisManager key properties."""
+    IS_COMPUTED = 'is_computed'
+    MAX_DEPTH = 'max_depth'
+    NUM_LEAVES = 'num_leaves'
+    FILTER_FEATURES = 'filter_features'
+    REPORTS = 'reports'

--- a/raitools/tests/error_analysis_validator.py
+++ b/raitools/tests/error_analysis_validator.py
@@ -12,11 +12,15 @@ ERROR = 'error'
 ID = 'id'
 
 
-def validate_error_analysis(rai_analyzer):
-    rai_analyzer.error_analysis.add()
-    with pytest.raises(DuplicateManagerConfigException):
+def setup_error_analysis(rai_analyzer, add_ea=True):
+    if add_ea:
         rai_analyzer.error_analysis.add()
+        with pytest.raises(DuplicateManagerConfigException):
+            rai_analyzer.error_analysis.add()
     rai_analyzer.error_analysis.compute()
+
+
+def validate_error_analysis(rai_analyzer):
     reports = rai_analyzer.error_analysis.get()
     assert isinstance(reports, list)
     assert len(reports) == 1

--- a/raitools/tests/test_rai_analyzer.py
+++ b/raitools/tests/test_rai_analyzer.py
@@ -17,7 +17,8 @@ from raitools._internal.constants import ManagerNames
 from explainer_manager_validator import (setup_explainer,
                                          validate_explainer)
 from counterfactual_manager_validator import validate_counterfactual
-from error_analysis_validator import validate_error_analysis
+from error_analysis_validator import (setup_error_analysis,
+                                      validate_error_analysis)
 
 LABELS = "labels"
 DESIRED_CLASS = 'desired_class'
@@ -43,7 +44,8 @@ class TestRAIAnalyzer(object):
             run_rai_analyzer(model, x_train, x_test, LABELS,
                              manager_type, manager_args, classes)
 
-    @pytest.mark.parametrize('manager_type', [ManagerNames.COUNTERFACTUAL,
+    @pytest.mark.parametrize('manager_type', [ManagerNames.ERROR_ANALYSIS,
+                                              ManagerNames.COUNTERFACTUAL,
                                               ManagerNames.EXPLAINER])
     def test_rai_analyzer_cancer(self, manager_type):
         x_train, x_test, y_train, y_test, feature_names, classes = \
@@ -59,7 +61,8 @@ class TestRAIAnalyzer(object):
             run_rai_analyzer(model, x_train, x_test, LABELS,
                              manager_type, manager_args, classes)
 
-    @pytest.mark.parametrize('manager_type', [ManagerNames.EXPLAINER])
+    @pytest.mark.parametrize('manager_type', [ManagerNames.ERROR_ANALYSIS,
+                                              ManagerNames.EXPLAINER])
     def test_rai_analyzer_binary(self, manager_type):
         x_train, y_train, x_test, y_test, classes = \
             create_binary_classification_dataset()
@@ -103,6 +106,8 @@ def run_rai_analyzer(model, x_train, x_test, target_column,
                                task_type=task_type)
     if manager_type == ManagerNames.EXPLAINER:
         setup_explainer(rai_analyzer)
+    if manager_type == ManagerNames.ERROR_ANALYSIS:
+        setup_error_analysis(rai_analyzer)
     validate_rai_analyzer(rai_analyzer, x_train, x_test, target_column,
                           task_type)
     if manager_type == ManagerNames.EXPLAINER:
@@ -120,7 +125,7 @@ def run_rai_analyzer(model, x_train, x_test, target_column,
     if manager_type == ManagerNames.ERROR_ANALYSIS:
         validate_error_analysis(rai_analyzer)
     with TemporaryDirectory() as tempdir:
-        path = Path(tempdir) / 'explanation'
+        path = Path(tempdir) / 'rai_test_path'
         # save the rai_analyzer
         rai_analyzer.save(path)
         # load the rai_analyzer
@@ -131,6 +136,8 @@ def run_rai_analyzer(model, x_train, x_test, target_column,
                               target_column, task_type)
         if manager_type == ManagerNames.EXPLAINER:
             validate_explainer(rai_analyzer, x_train, x_test, classes)
+        if manager_type == ManagerNames.ERROR_ANALYSIS:
+            validate_error_analysis(rai_analyzer)
 
 
 def validate_rai_analyzer(rai_analyzer, x_train, x_test, target_column,


### PR DESCRIPTION
implement the save, load and list functions for the error analysis manager
save:
saves the reports and configs to json, and relies on rai_analyzer to save everything else
load:
loads the reports and configs from json, and relies on rai_analyzer to load everything else, and then references the variables to local state from there
list:
lists the values on the configs (max depth, num leaves, features in matrix filter and whether the error report has been computed)