### PR TITLE
Missing config in raitools

### DIFF
--- a/raitools/raitools/_config/__init__.py
+++ b/raitools/raitools/_config/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Internal configuration of Responsible AI Analyzer."""


### PR DESCRIPTION
The `_config` directory needs an `__init__.py` file as well

Signed-off-by: Richard Edgar <riedgar@microsoft.com>