### PR TITLE
Fix the incorrect class member on loading explanations

### DIFF
--- a/responsibleai/responsibleai/_managers/explainer_manager.py
+++ b/responsibleai/responsibleai/_managers/explainer_manager.py
@@ -28,6 +28,7 @@ U_EVALUATION_EXAMPLES = '_evaluation_examples'
 FEATURES = 'features'
 META_JSON = Metadata.META_JSON
 MODEL = Metadata.MODEL
+EXPLANATION = '_explanation'
 
 
 class ExplainerManager(BaseManager):
@@ -194,7 +195,7 @@ class ExplainerManager(BaseManager):
         explanation_path = top_dir / ManagerNames.EXPLAINER
         if explanation_path.exists():
             explanation = load_explanation(explanation_path)
-            inst.__dict__['_' + ManagerNames.EXPLAINER] = explanation
+            inst.__dict__[EXPLANATION] = explanation
         inst.__dict__['_' + MODEL] = model_analysis.model
 
         with open(top_dir / META_JSON, 'r') as meta_file:

--- a/responsibleai/tests/test_model_analysis.py
+++ b/responsibleai/tests/test_model_analysis.py
@@ -124,14 +124,14 @@ def run_model_analysis(model, x_train, x_test, target_column,
                                 desired_class, desired_range)
     if manager_type == ManagerNames.ERROR_ANALYSIS:
         validate_error_analysis(model_analysis)
+
     with TemporaryDirectory() as tempdir:
         path = Path(tempdir) / 'rai_test_path'
         # save the model_analysis
         model_analysis.save(path)
         # load the model_analysis
         model_analysis = ModelAnalysis.load(path)
-        if manager_type == ManagerNames.EXPLAINER:
-            setup_explainer(model_analysis)
+
         validate_model_analysis(model_analysis, x_train, x_test,
                                 target_column, task_type)
         if manager_type == ManagerNames.EXPLAINER:


### PR DESCRIPTION
It seems like in _load() the explanation would be assigned to '_explainer' but it needed to be assigned to '_explanation' instead.