### PR TITLE
Change vscode linting settings for Python

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -71,5 +71,7 @@
     "sdist",
     "shap",
     "uifabric"
-  ]
+  ],
+  "python.linting.flake8Enabled": true,
+  "python.linting.flake8Args": ["--max-line-length=80"]
 }


### PR DESCRIPTION
Set the vscode settings for the repo to use flake8 for Python code.