### PR TITLE
Add tests for large package dependencies

### DIFF
--- a/responsibleai/requirements-dev.txt
+++ b/responsibleai/requirements-dev.txt
@@ -24,4 +24,6 @@ scrapbook
 jupyter
 nbval
 
+# Required for responsibleai package tests
+deptree~=0.0.10
 xgboost<=1.0.0

--- a/responsibleai/tests/test_dependencies.py
+++ b/responsibleai/tests/test_dependencies.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import pytest
+import subprocess
+
+
+REQUIRED_DEPENDENCIES = [
+    'econml',
+    'dice-ml',
+    'interpret-community',
+]
+
+DISALLOWED_DEPENDENCIES = [
+    'tensorflow',
+    'keras',
+    'pytorch',
+    'matplotlib',
+]
+
+
+@pytest.fixture(scope='class')
+def dep_trees():
+    trees = {}
+    for dep in REQUIRED_DEPENDENCIES:
+        trees[dep] = str(subprocess.check_output(['deptree', dep]))
+    return trees
+
+
+class TestDependencies:
+
+    @pytest.mark.parametrize('required', REQUIRED_DEPENDENCIES)
+    @pytest.mark.parametrize('disallowed', DISALLOWED_DEPENDENCIES)
+    def test_econml_dependencies(self, dep_trees, required, disallowed):
+        tree = dep_trees[required]
+        assert tree is not None
+        assert disallowed not in tree


### PR DESCRIPTION
These tests check dependencies of the `responsibleai` package to ensure that the dependency tree stays manageable.