### PR TITLE
Standardize X variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Please refer to [Interpret-Community](https://github.com/interpretml/interpret-c
 ```python
 from raiwidgets import ExplanationDashboard
 
-ExplanationDashboard(global_explanation, model, dataset=x_test, true_y=y_test)
+ExplanationDashboard(global_explanation, model, dataset=X_test, true_y=y_test)
 ```
 Once you load the visualization dashboard, you can investigate different aspects of your dataset and trained model via four tab views: 
 

--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -61,11 +61,11 @@ def create_iris_data():
     # Import Iris dataset
     iris = load_iris()
     # Split data into train and test
-    x_train, x_test, y_train, y_validation = train_test_split(
+    X_train, X_test, y_train, y_validation = train_test_split(
         iris.data, iris.target, test_size=0.2, random_state=0)
     feature_names = [name.replace(' (cm)', '') for name in iris.feature_names]
     classes = iris.target_names
-    return x_train, x_test, y_train, y_validation, feature_names, classes
+    return X_train, X_test, y_train, y_validation, feature_names, classes
 
 
 def create_cancer_data():
@@ -73,27 +73,27 @@ def create_cancer_data():
     classes = breast_cancer_data.target_names.tolist()
 
     # Split data into train and test
-    x_train, x_test, y_train, y_test = train_test_split(
+    X_train, X_test, y_train, y_test = train_test_split(
         breast_cancer_data.data, breast_cancer_data.target,
         test_size=0.2, random_state=0)
     feature_names = breast_cancer_data.feature_names
     classes = breast_cancer_data.target_names.tolist()
-    return x_train, x_test, y_train, y_test, feature_names, classes
+    return X_train, X_test, y_train, y_test, feature_names, classes
 
 
 def create_binary_classification_dataset():
     X, y = make_classification()
 
     # Split data into train and test
-    x_train, x_test, y_train, y_test = train_test_split(X,
+    X_train, X_test, y_train, y_test = train_test_split(X,
                                                         y,
                                                         test_size=0.2,
                                                         random_state=0)
     classes = np.unique(y_train).tolist()
-    feature_names = ["col" + str(i) for i in list(range(x_train.shape[1]))]
-    x_train = pd.DataFrame(x_train, columns=feature_names)
-    x_test = pd.DataFrame(x_test, columns=feature_names)
-    return x_train, y_train, x_test, y_test, classes
+    feature_names = ["col" + str(i) for i in list(range(X_train.shape[1]))]
+    X_train = pd.DataFrame(X_train, columns=feature_names)
+    X_test = pd.DataFrame(X_test, columns=feature_names)
+    return X_train, y_train, X_test, y_test, classes
 
 
 def create_simple_titanic_data():
@@ -115,17 +115,17 @@ def create_simple_titanic_data():
     return X_train, X_test, y_train, y_test, num_features, cat_features
 
 
-def create_models(x_train, y_train):
-    svm_model = create_sklearn_svm_classifier(x_train, y_train)
-    log_reg_model = create_sklearn_logistic_regressor(x_train, y_train)
-    xgboost_model = create_xgboost_classifier(x_train, y_train)
-    lgbm_model = create_lightgbm_classifier(x_train, y_train)
-    rf_model = create_sklearn_random_forest_classifier(x_train, y_train)
+def create_models(X_train, y_train):
+    svm_model = create_sklearn_svm_classifier(X_train, y_train)
+    log_reg_model = create_sklearn_logistic_regressor(X_train, y_train)
+    xgboost_model = create_xgboost_classifier(X_train, y_train)
+    lgbm_model = create_lightgbm_classifier(X_train, y_train)
+    rf_model = create_sklearn_random_forest_classifier(X_train, y_train)
 
     return [svm_model, log_reg_model, xgboost_model, lgbm_model, rf_model]
 
 
-def create_titanic_pipeline(x_train, y_train):
+def create_titanic_pipeline(X_train, y_train):
     def conv(X):
         if isinstance(X, pd.Series):
             return X.values
@@ -154,5 +154,5 @@ def create_titanic_pipeline(x_train, y_train):
     clf = Pipeline(steps=[('preprocessor', transformations),
                           ('classifier',
                            LogisticRegression(solver='lbfgs'))])
-    clf.fit(x_train, y_train)
+    clf.fit(X_train, y_train)
     return clf

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -12,50 +12,50 @@ TOL = 1e-10
 class TestImportances(object):
 
     def test_importances_iris(self):
-        x_train, x_test, y_train, y_test, feature_names, _ = create_iris_data()
+        X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
 
-        models = create_models(x_train, y_train)
+        models = create_models(X_train, y_train)
 
         for model in models:
             categorical_features = []
-            run_error_analyzer(model, x_test, y_test, feature_names,
+            run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features)
 
     def test_importances_cancer(self):
-        x_train, x_test, y_train, y_test, feature_names, _ = \
+        X_train, X_test, y_train, y_test, feature_names, _ = \
             create_cancer_data()
 
-        models = create_models(x_train, y_train)
+        models = create_models(X_train, y_train)
 
         for model in models:
             categorical_features = []
-            run_error_analyzer(model, x_test, y_test, feature_names,
+            run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features)
 
     def test_importances_binary_classification(self):
-        x_train, y_train, x_test, y_test, _ = \
+        X_train, y_train, X_test, y_test, _ = \
             create_binary_classification_dataset()
-        feature_names = list(x_train.columns)
-        models = create_models(x_train, y_train)
+        feature_names = list(X_train.columns)
+        models = create_models(X_train, y_train)
 
         for model in models:
             categorical_features = []
-            run_error_analyzer(model, x_test, y_test, feature_names,
+            run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features)
 
     def test_importances_titanic(self):
-        x_train, x_test, y_train, y_test, numeric, categorical = \
+        X_train, X_test, y_train, y_test, numeric, categorical = \
             create_simple_titanic_data()
         feature_names = categorical + numeric
-        clf = create_titanic_pipeline(x_train, y_train)
+        clf = create_titanic_pipeline(X_train, y_train)
         categorical_features = categorical
-        run_error_analyzer(clf, x_test, y_test, feature_names,
+        run_error_analyzer(clf, X_test, y_test, feature_names,
                            categorical_features)
 
 
-def run_error_analyzer(model, x_test, y_test, feature_names,
+def run_error_analyzer(model, X_test, y_test, feature_names,
                        categorical_features):
-    model_analyzer = ModelAnalyzer(model, x_test, y_test,
+    model_analyzer = ModelAnalyzer(model, X_test, y_test,
                                    feature_names,
                                    categorical_features)
     scores = model_analyzer.compute_importances()

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -14,59 +14,59 @@ from erroranalysis._internal.constants import ModelTask
 class TestMatrixFilter(object):
 
     def test_matrix_filter_iris(self):
-        x_train, x_test, y_train, y_test, feature_names, _ = create_iris_data()
+        X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
 
-        models = create_models(x_train, y_train)
+        models = create_models(X_train, y_train)
 
         for model in models:
             categorical_features = []
-            run_error_analyzer(model, x_test, y_test, feature_names,
+            run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features,
                                model_task=ModelTask.CLASSIFICATION)
 
     def test_matrix_filter_cancer(self):
-        x_train, x_test, y_train, y_test, feature_names, _ = \
+        X_train, X_test, y_train, y_test, feature_names, _ = \
             create_cancer_data()
 
-        models = create_models(x_train, y_train)
+        models = create_models(X_train, y_train)
 
         for model in models:
             categorical_features = []
-            run_error_analyzer(model, x_test, y_test, feature_names,
+            run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features,
                                model_task=ModelTask.CLASSIFICATION)
 
     def test_matrix_filter_binary_classification(self):
-        x_train, y_train, x_test, y_test, _ = \
+        X_train, y_train, X_test, y_test, _ = \
             create_binary_classification_dataset()
-        feature_names = list(x_train.columns)
-        models = create_models(x_train, y_train)
+        feature_names = list(X_train.columns)
+        models = create_models(X_train, y_train)
 
         for model in models:
             categorical_features = []
-            run_error_analyzer(model, x_test, y_test, feature_names,
+            run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features,
                                model_task=ModelTask.CLASSIFICATION)
 
     def test_matrix_filter_titanic(self):
-        x_train, x_test, y_train, y_test, numeric, categorical = \
+        X_train, X_test, y_train, y_test, numeric, categorical = \
             create_simple_titanic_data()
         feature_names = categorical + numeric
-        clf = create_titanic_pipeline(x_train, y_train)
+        clf = create_titanic_pipeline(X_train, y_train)
         categorical_features = categorical
-        run_error_analyzer(clf, x_test, y_test, feature_names,
+        run_error_analyzer(clf, X_test, y_test, feature_names,
                            categorical_features,
                            model_task=ModelTask.CLASSIFICATION)
 
 
 def run_error_analyzer(model,
-                       x_test,
+                       X_test,
                        y_test,
                        feature_names,
                        categorical_features,
                        model_task):
     error_analyzer = ModelAnalyzer(model,
-                                   x_test,
+                                   X_test,
                                    y_test,
                                    feature_names,
                                    categorical_features,
@@ -77,8 +77,8 @@ def run_error_analyzer(model,
     composite_filters = None
     json_matrix = error_analyzer.compute_matrix(features, filters,
                                                 composite_filters)
-    expected_count = len(x_test)
-    expected_false_count = sum(model.predict(x_test) != y_test)
+    expected_count = len(X_test)
+    expected_false_count = sum(model.predict(X_test) != y_test)
     validate_matrix(json_matrix, expected_count, expected_false_count)
 
 

--- a/erroranalysis/tests/test_surrogate_error_tree.py
+++ b/erroranalysis/tests/test_surrogate_error_tree.py
@@ -13,19 +13,19 @@ ID = 'id'
 class TestSurrogateErrorTree(object):
 
     def test_surrogate_error_tree_iris(self):
-        x_train, x_test, y_train, y_test, feature_names, _ = create_iris_data()
+        X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
 
-        models = create_models(x_train, y_train)
+        models = create_models(X_train, y_train)
 
         for model in models:
             categorical_features = []
-            run_error_analyzer(model, x_test, y_test, feature_names,
+            run_error_analyzer(model, X_test, y_test, feature_names,
                                categorical_features)
 
 
-def run_error_analyzer(model, x_test, y_test, feature_names,
+def run_error_analyzer(model, X_test, y_test, feature_names,
                        categorical_features):
-    error_analyzer = ModelAnalyzer(model, x_test, y_test,
+    error_analyzer = ModelAnalyzer(model, X_test, y_test,
                                    feature_names,
                                    categorical_features)
     # features, filters, composite_filters
@@ -41,4 +41,4 @@ def run_error_analyzer(model, x_test, y_test, feature_names,
     assert PARENTID in json_tree[0]
     assert json_tree[0][PARENTID] is None
     assert SIZE in json_tree[0]
-    assert json_tree[0][SIZE] == len(x_test)
+    assert json_tree[0][SIZE] == len(X_test)

--- a/notebooks/erroranalysis-dashboard-multiclass.ipynb
+++ b/notebooks/erroranalysis-dashboard-multiclass.ipynb
@@ -80,7 +80,7 @@
    "source": [
     "# Split data into train and test\n",
     "from sklearn.model_selection import train_test_split\n",
-    "x_train, x_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=0)"
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=0)"
    ]
   },
   {
@@ -98,7 +98,7 @@
    "source": [
     "from sklearn.linear_model import LogisticRegression\n",
     "clf = svm.SVC(gamma=0.001, C=100., probability=True)\n",
-    "model = clf.fit(x_train, y_train)"
+    "model = clf.fit(X_train, y_train)"
    ]
   },
   {
@@ -108,7 +108,7 @@
    "outputs": [],
    "source": [
     "# Notice the model makes a fair number of errors\n",
-    "print(\"number of errors on test dataset: \" + str(sum(model.predict(x_test) != y_test)))"
+    "print(\"number of errors on test dataset: \" + str(sum(model.predict(X_test) != y_test)))"
    ]
   },
   {
@@ -127,8 +127,8 @@
    "outputs": [],
    "source": [
     "from raiwidgets import ErrorAnalysisDashboard\n",
-    "predictions = model.predict(x_test)\n",
-    "ErrorAnalysisDashboard(dataset=x_test, true_y=y_test, features=feature_names, pred_y=predictions)"
+    "predictions = model.predict(X_test)\n",
+    "ErrorAnalysisDashboard(dataset=X_test, true_y=y_test, features=feature_names, pred_y=predictions)"
    ]
   },
   {
@@ -147,7 +147,7 @@
     "from interpret_community.common.constants import ModelTask\n",
     "# Train the LightGBM surrogate model using MimicExplaner\n",
     "model_task = ModelTask.Classification\n",
-    "explainer = MimicExplainer(model, x_train, LGBMExplainableModel,\n",
+    "explainer = MimicExplainer(model, X_train, LGBMExplainableModel,\n",
     "                           augment_data=True, max_num_of_augmentations=10,\n",
     "                           features=feature_names, classes=classes, model_task=model_task)"
    ]
@@ -167,8 +167,8 @@
    "outputs": [],
    "source": [
     "# Passing in test dataset for evaluation examples - note it must be a representative sample of the original data\n",
-    "# x_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
-    "global_explanation = explainer.explain_global(x_test)"
+    "# X_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
+    "global_explanation = explainer.explain_global(X_test)"
    ]
   },
   {
@@ -212,7 +212,7 @@
    },
    "outputs": [],
    "source": [
-    "ErrorAnalysisDashboard(global_explanation, model, dataset=x_test, true_y=y_test)"
+    "ErrorAnalysisDashboard(global_explanation, model, dataset=X_test, true_y=y_test)"
    ]
   }
  ],

--- a/notebooks/erroranalysis-dashboard-regression.ipynb
+++ b/notebooks/erroranalysis-dashboard-regression.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "# Split data into train and test\n",
     "from sklearn.model_selection import train_test_split\n",
-    "x_train, x_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=0)"
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5, random_state=0)"
    ]
   },
   {
@@ -96,7 +96,7 @@
    "outputs": [],
    "source": [
     "clf = svm.SVR(gamma=0.001, C=100.)\n",
-    "model = clf.fit(x_train, y_train)"
+    "model = clf.fit(X_train, y_train)"
    ]
   },
   {
@@ -106,7 +106,7 @@
    "outputs": [],
    "source": [
     "# Notice the model makes a fair amount of error\n",
-    "print(\"average abs error on test dataset: \" + str(sum(abs(model.predict(x_test) - y_test))/y_test.shape[0]))"
+    "print(\"average abs error on test dataset: \" + str(sum(abs(model.predict(X_test) - y_test))/y_test.shape[0]))"
    ]
   },
   {
@@ -125,8 +125,8 @@
    "outputs": [],
    "source": [
     "from raiwidgets import ErrorAnalysisDashboard\n",
-    "predictions = model.predict(x_test)\n",
-    "ErrorAnalysisDashboard(dataset=x_test, true_y=y_test, features=feature_names, pred_y=predictions, model_task='regression')"
+    "predictions = model.predict(X_test)\n",
+    "ErrorAnalysisDashboard(dataset=X_test, true_y=y_test, features=feature_names, pred_y=predictions, model_task='regression')"
    ]
   },
   {
@@ -145,7 +145,7 @@
     "from interpret_community.common.constants import ModelTask\n",
     "# Train the LightGBM surrogate model using MimicExplaner\n",
     "model_task = ModelTask.Regression\n",
-    "explainer = MimicExplainer(model, x_train, LGBMExplainableModel,\n",
+    "explainer = MimicExplainer(model, X_train, LGBMExplainableModel,\n",
     "                           augment_data=True, max_num_of_augmentations=10,\n",
     "                           features=feature_names, model_task=model_task)"
    ]
@@ -165,8 +165,8 @@
    "outputs": [],
    "source": [
     "# Passing in test dataset for evaluation examples - note it must be a representative sample of the original data\n",
-    "# x_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
-    "global_explanation = explainer.explain_global(x_test)"
+    "# X_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
+    "global_explanation = explainer.explain_global(X_test)"
    ]
   },
   {
@@ -210,7 +210,7 @@
    },
    "outputs": [],
    "source": [
-    "ErrorAnalysisDashboard(global_explanation, model, dataset=x_test, true_y=y_test, model_task='regression')"
+    "ErrorAnalysisDashboard(global_explanation, model, dataset=X_test, true_y=y_test, model_task='regression')"
    ]
   }
  ],

--- a/notebooks/erroranalysis-interpretability-dashboard-breast-cancer.ipynb
+++ b/notebooks/erroranalysis-interpretability-dashboard-breast-cancer.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "# Split data into train and test\n",
     "from sklearn.model_selection import train_test_split\n",
-    "x_train, x_test, y_train, y_test = train_test_split(breast_cancer_data.data, breast_cancer_data.target, test_size=0.2, random_state=0)"
+    "X_train, X_test, y_train, y_test = train_test_split(breast_cancer_data.data, breast_cancer_data.target, test_size=0.2, random_state=0)"
    ]
   },
   {
@@ -96,7 +96,7 @@
    "outputs": [],
    "source": [
     "clf = LGBMClassifier(n_estimators=1)\n",
-    "model = clf.fit(x_train, y_train)"
+    "model = clf.fit(X_train, y_train)"
    ]
   },
   {
@@ -115,9 +115,9 @@
    "outputs": [],
    "source": [
     "from raiwidgets import ErrorAnalysisDashboard\n",
-    "predictions = clf.predict(x_test)\n",
+    "predictions = clf.predict(X_test)\n",
     "features = breast_cancer_data.feature_names\n",
-    "ErrorAnalysisDashboard(dataset=x_test, true_y=y_test, features=features, pred_y=predictions)"
+    "ErrorAnalysisDashboard(dataset=X_test, true_y=y_test, features=features, pred_y=predictions)"
    ]
   },
   {
@@ -135,7 +135,7 @@
    "source": [
     "# 1. Using SHAP TabularExplainer\n",
     "explainer = TabularExplainer(model, \n",
-    "                             x_train, \n",
+    "                             X_train, \n",
     "                             features=breast_cancer_data.feature_names, \n",
     "                             classes=classes)"
    ]
@@ -155,8 +155,8 @@
    "outputs": [],
    "source": [
     "# Passing in test dataset for evaluation examples - note it must be a representative sample of the original data\n",
-    "# x_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
-    "global_explanation = explainer.explain_global(x_test)"
+    "# X_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
+    "global_explanation = explainer.explain_global(X_test)"
    ]
   },
   {
@@ -224,7 +224,7 @@
     "\n",
     "# E.g., Explain the first data point in the test set\n",
     "instance_num = 1\n",
-    "local_explanation = explainer.explain_local(x_test[:instance_num])"
+    "local_explanation = explainer.explain_local(X_test[:instance_num])"
    ]
   },
   {
@@ -234,7 +234,7 @@
    "outputs": [],
    "source": [
     "# Get the prediction for the first member of the test set and explain why model made that prediction\n",
-    "prediction_value = clf.predict(x_test)[instance_num]\n",
+    "prediction_value = clf.predict(X_test)[instance_num]\n",
     "\n",
     "sorted_local_importance_values = local_explanation.get_ranked_local_values()[prediction_value]\n",
     "sorted_local_importance_names = local_explanation.get_ranked_local_names()[prediction_value]\n",
@@ -266,7 +266,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ExplanationDashboard(global_explanation, model, dataset=x_test, true_y=y_test)"
+    "ExplanationDashboard(global_explanation, model, dataset=X_test, true_y=y_test)"
    ]
   },
   {
@@ -284,7 +284,7 @@
    },
    "outputs": [],
    "source": [
-    "ErrorAnalysisDashboard(global_explanation, model, dataset=x_test, true_y=y_test)"
+    "ErrorAnalysisDashboard(global_explanation, model, dataset=X_test, true_y=y_test)"
    ]
   },
   {

--- a/notebooks/erroranalysis-interpretability-dashboard-census.ipynb
+++ b/notebooks/erroranalysis-interpretability-dashboard-census.ipynb
@@ -217,7 +217,7 @@
    "outputs": [],
    "source": [
     "# Passing in test dataset for evaluation examples - note it must be a representative sample of the original data\n",
-    "# x_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
+    "# X_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
     "global_explanation = explainer.explain_global(X_test_original)"
    ]
   },

--- a/notebooks/interpretability-dashboard-employee-attrition.ipynb
+++ b/notebooks/interpretability-dashboard-employee-attrition.ipynb
@@ -109,7 +109,7 @@
    "source": [
     "# Split data into train and test\n",
     "from sklearn.model_selection import train_test_split\n",
-    "x_train, x_test, y_train, y_test = train_test_split(attritionXData, \n",
+    "X_train, X_test, y_train, y_test = train_test_split(attritionXData, \n",
     "                                                    target, \n",
     "                                                    test_size=0.2,\n",
     "                                                    random_state=0,\n",
@@ -187,7 +187,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = clf.fit(x_train, y_train)"
+    "model = clf.fit(X_train, y_train)"
    ]
   },
   {
@@ -208,7 +208,7 @@
     "# Using SHAP TabularExplainer\n",
     "from interpret.ext.blackbox import TabularExplainer\n",
     "explainer = TabularExplainer(clf.steps[-1][1], \n",
-    "                             initialization_examples=x_train, \n",
+    "                             initialization_examples=X_train, \n",
     "                             features=attritionXData.columns, \n",
     "                             classes=['Leaving', 'Staying'], \n",
     "                             transformations=transformations)"
@@ -229,8 +229,8 @@
    "outputs": [],
    "source": [
     "# Passing in test dataset for evaluation examples - note it must be a representative sample of the original data\n",
-    "# x_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
-    "global_explanation = explainer.explain_global(x_test)"
+    "# X_train can be passed as well, but with more examples explanations will take longer although they may be more accurate\n",
+    "global_explanation = explainer.explain_global(X_test)"
    ]
   },
   {
@@ -260,7 +260,7 @@
     "# You can pass a specific data point or a group of data points to the explain_local function\n",
     "# E.g., Explain the first data point in the test set\n",
     "instance_num = 1\n",
-    "local_explanation = explainer.explain_local(x_test[:instance_num])"
+    "local_explanation = explainer.explain_local(X_test[:instance_num])"
    ]
   },
   {
@@ -272,7 +272,7 @@
    "outputs": [],
    "source": [
     "# Get the prediction for the first member of the test set and explain why model made that prediction\n",
-    "prediction_value = clf.predict(x_test)[instance_num]\n",
+    "prediction_value = clf.predict(X_test)[instance_num]\n",
     "\n",
     "sorted_local_importance_values = local_explanation.get_ranked_local_values()[prediction_value]\n",
     "sorted_local_importance_names = local_explanation.get_ranked_local_names()[prediction_value]"
@@ -311,7 +311,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ExplanationDashboard(global_explanation, model, dataset=x_test, true_y=y_test.values)"
+    "ExplanationDashboard(global_explanation, model, dataset=X_test, true_y=y_test.values)"
    ]
   }
  ],

--- a/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
@@ -51,11 +51,11 @@ class ModelAnalysisDashboardInput:
         self.dashboard_input.counterfactualData = [
             self._get_counterfactual(i)
             for i in self._analysis.counterfactual.get()]
-        x_test = analysis.test.drop(columns=[analysis.target_column])
+        X_test = analysis.test.drop(columns=[analysis.target_column])
         y_test = analysis.test[analysis.target_column]
-        self._error_analyzer = ModelAnalyzer(model, x_test,
+        self._error_analyzer = ModelAnalyzer(model, X_test,
                                              y_test,
-                                             x_test.columns.values.tolist(),
+                                             X_test.columns.values.tolist(),
                                              analysis.categorical_features)
 
     def on_predict(self, data):

--- a/raiwidgets/tests/explanation.py
+++ b/raiwidgets/tests/explanation.py
@@ -14,24 +14,24 @@ y = iris['target']
 classes = iris['target_names']
 feature_names = iris['feature_names']
 
-x_train, x_test, y_train, y_test = train_test_split(
+X_train, X_test, y_train, y_test = train_test_split(
     X, y, test_size=0.2, random_state=0)
 
 clf = svm.SVC(gamma=0.001, C=100., probability=True)
-model = clf.fit(x_train, y_train)
+model = clf.fit(X_train, y_train)
 
 explainer = TabularExplainer(model,
-                             x_train,
+                             X_train,
                              features=feature_names,
                              classes=classes)
 
-global_explanation = explainer.explain_global(x_test)
+global_explanation = explainer.explain_global(X_test)
 
 
 instance_num = 0
-local_explanation = explainer.explain_local(x_test[instance_num, :])
+local_explanation = explainer.explain_local(X_test[instance_num, :])
 
-prediction_value = clf.predict(x_test)[instance_num]
+prediction_value = clf.predict(X_test)[instance_num]
 
 sorted_local_importance_values = local_explanation.get_ranked_local_values()[
     prediction_value]
@@ -39,7 +39,7 @@ sorted_local_importance_names = local_explanation.get_ranked_local_names()[
     prediction_value]
 
 
-ExplanationDashboard(global_explanation, model, dataset=x_test, true_y=y_test)
-ModelPerformanceDashboard(model, dataset=x_test, true_y=y_test)
+ExplanationDashboard(global_explanation, model, dataset=X_test, true_y=y_test)
+ModelPerformanceDashboard(model, dataset=X_test, true_y=y_test)
 
 input("Press Enter to continue...")

--- a/raiwidgets/tests/model_analysis.py
+++ b/raiwidgets/tests/model_analysis.py
@@ -11,16 +11,16 @@ x, y = shap.datasets.adult()
 y = [1 if r else 0 for r in y]
 
 
-x_train, x_test, y_train, y_test = sklearn.model_selection.train_test_split(
+X_train, X_test, y_train, y_test = sklearn.model_selection.train_test_split(
     x, y, test_size=0.2, random_state=7)
 
 knn = sklearn.neighbors.KNeighborsClassifier()
-knn.fit(x_train, y_train)
+knn.fit(X_train, y_train)
 
 
 train = pd.merge(x, pd.DataFrame(
     y, columns=["income"]), left_index=True, right_index=True)
-test = pd.merge(x_test, pd.DataFrame(y_test, columns=[
+test = pd.merge(X_test, pd.DataFrame(y_test, columns=[
                 "income"]), left_index=True, right_index=True)
 
 ma = ModelAnalysis(knn, train, test, "income", "classification",

--- a/responsibleai/tests/common_utils.py
+++ b/responsibleai/tests/common_utils.py
@@ -63,11 +63,11 @@ def create_iris_data():
     # Import Iris dataset
     iris = load_iris()
     # Split data into train and test
-    x_train, x_test, y_train, y_test = train_test_split(
+    X_train, X_test, y_train, y_test = train_test_split(
         iris.data, iris.target, test_size=0.2, random_state=0)
     feature_names = [name.replace(' (cm)', '') for name in iris.feature_names]
     classes = iris.target_names
-    return x_train, x_test, y_train, y_test, feature_names, classes
+    return X_train, X_test, y_train, y_test, feature_names, classes
 
 
 def create_cancer_data():
@@ -75,50 +75,50 @@ def create_cancer_data():
     classes = breast_cancer_data.target_names.tolist()
 
     # Split data into train and test
-    x_train, x_test, y_train, y_test = train_test_split(
+    X_train, X_test, y_train, y_test = train_test_split(
         breast_cancer_data.data, breast_cancer_data.target,
         test_size=0.2, random_state=0)
     feature_names = breast_cancer_data.feature_names
     classes = breast_cancer_data.target_names.tolist()
-    return x_train, x_test, y_train, y_test, feature_names, classes
+    return X_train, X_test, y_train, y_test, feature_names, classes
 
 
 def create_binary_classification_dataset():
     X, y = make_classification()
 
     # Split data into train and test
-    x_train, x_test, y_train, y_test = train_test_split(X,
+    X_train, X_test, y_train, y_test = train_test_split(X,
                                                         y,
                                                         test_size=0.2,
                                                         random_state=0)
     classes = np.unique(y_train).tolist()
-    feature_names = ["col" + str(i) for i in list(range(x_train.shape[1]))]
-    x_train = pd.DataFrame(x_train, columns=feature_names)
-    x_test = pd.DataFrame(x_test, columns=feature_names)
-    return x_train, y_train, x_test, y_test, classes
+    feature_names = ["col" + str(i) for i in list(range(X_train.shape[1]))]
+    X_train = pd.DataFrame(X_train, columns=feature_names)
+    X_test = pd.DataFrame(X_test, columns=feature_names)
+    return X_train, y_train, X_test, y_test, classes
 
 
 def create_boston_data():
     # Import Boston housing dataset
     boston = load_boston()
     # Split data into train and test
-    x_train, x_test, y_train, y_validation = train_test_split(
+    X_train, X_test, y_train, y_validation = train_test_split(
         boston.data, boston.target,
         test_size=0.2, random_state=7)
-    return x_train, x_test, y_train, y_validation, boston.feature_names
+    return X_train, X_test, y_train, y_validation, boston.feature_names
 
 
-def create_models_classification(x_train, y_train):
-    svm_model = create_sklearn_svm_classifier(x_train, y_train)
-    log_reg_model = create_sklearn_logistic_regressor(x_train, y_train)
-    xgboost_model = create_xgboost_classifier(x_train, y_train)
-    lgbm_model = create_lightgbm_classifier(x_train, y_train)
-    rf_model = create_sklearn_random_forest_classifier(x_train, y_train)
+def create_models_classification(X_train, y_train):
+    svm_model = create_sklearn_svm_classifier(X_train, y_train)
+    log_reg_model = create_sklearn_logistic_regressor(X_train, y_train)
+    xgboost_model = create_xgboost_classifier(X_train, y_train)
+    lgbm_model = create_lightgbm_classifier(X_train, y_train)
+    rf_model = create_sklearn_random_forest_classifier(X_train, y_train)
 
     return [svm_model, log_reg_model, xgboost_model, lgbm_model, rf_model]
 
 
-def create_models_regression(x_train, y_train):
-    rf_model = create_sklearn_random_forest_regressor(x_train, y_train)
+def create_models_regression(X_train, y_train):
+    rf_model = create_sklearn_random_forest_regressor(X_train, y_train)
 
     return [rf_model]

--- a/responsibleai/tests/counterfactual_manager_validator.py
+++ b/responsibleai/tests/counterfactual_manager_validator.py
@@ -8,9 +8,9 @@ from responsibleai.exceptions import (
 )
 
 
-def validate_counterfactual(cf_analyzer, x_train, target_column,
+def validate_counterfactual(cf_analyzer, X_train, target_column,
                             desired_class=None, desired_range=None):
-    continuous_features = list(set(x_train.columns) - set([target_column]))
+    continuous_features = list(set(X_train.columns) - set([target_column]))
 
     # Add the first configuration
     cf_analyzer.counterfactual.add(continuous_features=continuous_features,

--- a/responsibleai/tests/explainer_manager_validator.py
+++ b/responsibleai/tests/explainer_manager_validator.py
@@ -17,18 +17,18 @@ def setup_explainer(model_analysis, add_explainer=True):
     model_analysis.explainer.compute()
 
 
-def validate_explainer(model_analysis, x_train, x_test, classes):
+def validate_explainer(model_analysis, X_train, X_test, classes):
     explanations = model_analysis.explainer.get()
     assert isinstance(explanations, list)
     assert len(explanations) == 1
     explanation = explanations[0]
-    num_cols = len(x_train.columns) - 1
+    num_cols = len(X_train.columns) - 1
     if classes is not None:
         assert len(explanation.local_importance_values) == len(classes)
-        assert len(explanation.local_importance_values[0]) == len(x_test)
+        assert len(explanation.local_importance_values[0]) == len(X_test)
         assert len(explanation.local_importance_values[0][0]) == num_cols
     else:
-        assert len(explanation.local_importance_values) == len(x_test)
+        assert len(explanation.local_importance_values) == len(X_test)
         assert len(explanation.local_importance_values[0]) == num_cols
 
     properties = model_analysis.explainer.list()

--- a/responsibleai/tests/test_model_analysis.py
+++ b/responsibleai/tests/test_model_analysis.py
@@ -34,51 +34,51 @@ class TestModelAnalysis(object):
                                               ManagerNames.ERROR_ANALYSIS,
                                               ManagerNames.EXPLAINER])
     def test_model_analysis_iris(self, manager_type):
-        x_train, x_test, y_train, y_test, feature_names, classes = \
+        X_train, X_test, y_train, y_test, feature_names, classes = \
             create_iris_data()
-        x_train = pd.DataFrame(x_train, columns=feature_names)
-        x_test = pd.DataFrame(x_test, columns=feature_names)
-        models = create_models_classification(x_train, y_train)
-        x_train[LABELS] = y_train
-        x_test[LABELS] = y_test
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
+        models = create_models_classification(X_train, y_train)
+        X_train[LABELS] = y_train
+        X_test[LABELS] = y_test
         manager_args = {DESIRED_CLASS: 0}
 
         for model in models:
-            run_model_analysis(model, x_train, x_test, LABELS, [],
+            run_model_analysis(model, X_train, X_test, LABELS, [],
                                manager_type, manager_args, classes)
 
     @pytest.mark.parametrize('manager_type', [ManagerNames.ERROR_ANALYSIS,
                                               ManagerNames.COUNTERFACTUAL,
                                               ManagerNames.EXPLAINER])
     def test_model_analysis_cancer(self, manager_type):
-        x_train, x_test, y_train, y_test, feature_names, classes = \
+        X_train, X_test, y_train, y_test, feature_names, classes = \
             create_cancer_data()
-        x_train = pd.DataFrame(x_train, columns=feature_names)
-        x_test = pd.DataFrame(x_test, columns=feature_names)
-        models = create_models_classification(x_train, y_train)
-        x_train[LABELS] = y_train
-        x_test[LABELS] = y_test
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
+        models = create_models_classification(X_train, y_train)
+        X_train[LABELS] = y_train
+        X_test[LABELS] = y_test
         manager_args = {DESIRED_CLASS: 'opposite'}
 
         for model in models:
-            run_model_analysis(model, x_train, x_test, LABELS, [],
+            run_model_analysis(model, X_train, X_test, LABELS, [],
                                manager_type, manager_args, classes)
 
     @pytest.mark.parametrize('manager_type', [ManagerNames.CAUSAL,
                                               ManagerNames.ERROR_ANALYSIS,
                                               ManagerNames.EXPLAINER])
     def test_model_analysis_binary(self, manager_type):
-        x_train, y_train, x_test, y_test, classes = \
+        X_train, y_train, X_test, y_test, classes = \
             create_binary_classification_dataset()
-        x_train = pd.DataFrame(x_train)
-        x_test = pd.DataFrame(x_test)
-        models = create_models_classification(x_train, y_train)
-        x_train[LABELS] = y_train
-        x_test[LABELS] = y_test
+        X_train = pd.DataFrame(X_train)
+        X_test = pd.DataFrame(X_test)
+        models = create_models_classification(X_train, y_train)
+        X_train[LABELS] = y_train
+        X_test[LABELS] = y_test
         manager_args = None
 
         for model in models:
-            run_model_analysis(model, x_train, x_test, LABELS, [],
+            run_model_analysis(model, X_train, X_test, LABELS, [],
                                manager_type, manager_args,
                                classes=classes)
 
@@ -86,17 +86,17 @@ class TestModelAnalysis(object):
                                               ManagerNames.COUNTERFACTUAL,
                                               ManagerNames.EXPLAINER])
     def test_modelanalysis_boston(self, manager_type):
-        x_train, x_test, y_train, y_test, feature_names = \
+        X_train, X_test, y_train, y_test, feature_names = \
             create_boston_data()
-        x_train = pd.DataFrame(x_train, columns=feature_names)
-        x_test = pd.DataFrame(x_test, columns=feature_names)
-        models = create_models_regression(x_train, y_train)
-        x_train[LABELS] = y_train
-        x_test[LABELS] = y_test
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
+        models = create_models_regression(X_train, y_train)
+        X_train[LABELS] = y_train
+        X_test[LABELS] = y_test
         manager_args = {DESIRED_RANGE: [10, 20]}
 
         for model in models:
-            run_model_analysis(model, x_train, x_test, LABELS, ['RM'],
+            run_model_analysis(model, X_train, X_test, LABELS, ['RM'],
                                manager_type, manager_args)
 
 


### PR DESCRIPTION
In Python for machine learning the design matrix `X` is typically named with a capital `X` despite Python naming conventions to indicate a matrix-valued variable rather than a scalar or vector-valued variable.