### PR TITLE
fix on predict method to use correct dtypes

### DIFF
--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -119,6 +119,7 @@ class ErrorAnalysisDashboardInput:
 
         if isinstance(dataset, pd.DataFrame) and hasattr(dataset, 'columns'):
             self._dataframeColumns = dataset.columns
+            self._dfdtypes = dataset.dtypes
         try:
             list_dataset = self._convert_to_list(dataset)
         except Exception as ex:
@@ -408,6 +409,7 @@ class ErrorAnalysisDashboardInput:
         try:
             if self._dataframeColumns is not None:
                 data = pd.DataFrame(data, columns=self._dataframeColumns)
+                data = data.astype(dict(self._dfdtypes))
             if (self._is_classifier):
                 model_pred_proba = self._model.predict_proba(data)
                 prediction = self._convert_to_list(model_pred_proba)

--- a/raiwidgets/raiwidgets/explanation_dashboard_input.py
+++ b/raiwidgets/raiwidgets/explanation_dashboard_input.py
@@ -86,6 +86,7 @@ class ExplanationDashboardInput:
 
         if isinstance(dataset, pd.DataFrame) and hasattr(dataset, 'columns'):
             self._dataframeColumns = dataset.columns
+            self._dfdtypes = dataset.dtypes
         try:
             list_dataset = self._convert_to_list(dataset)
         except Exception as ex:
@@ -254,6 +255,7 @@ class ExplanationDashboardInput:
         try:
             if self._dataframeColumns is not None:
                 data = pd.DataFrame(data, columns=self._dataframeColumns)
+                data = data.astype(dict(self._dfdtypes))
             if (self._is_classifier):
                 prediction = self._convert_to_list(
                     self._model.predict_proba(data))


### PR DESCRIPTION
Customer had issue where what if panel was getting disabled.  When debugging we found that categorical dtypes were treated as object when we created dataframe which led to their lightgbm model failing.  Saving and converting the dtypes on predict fixed their issue, enabling the what if panel.