### PR TITLE
Add cards around components in model assessment dashboard

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.styles.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.styles.ts
@@ -12,6 +12,7 @@ export interface IAddTabButtonStyles {
   callout: IStyle;
   button: IStyle;
   splitter: IStyle;
+  buttonSection: IStyle;
 }
 
 export const addTabButtonStyles = (): IProcessedStyleSet<
@@ -26,6 +27,9 @@ export const addTabButtonStyles = (): IProcessedStyleSet<
           fontSize: "32px"
         }
       }
+    },
+    buttonSection: {
+      padding: "10px 0 10px 0"
     },
     callout: {
       padding: "1em",

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
@@ -61,7 +61,7 @@ export class AddTabButton extends React.Component<
   public render(): React.ReactNode {
     const style = addTabButtonStyles();
     return (
-      <>
+      <div style={{padding: "10px 0 10px 0"}}>
         <div className={style.splitter} />
         <Stack horizontal horizontalAlign={"center"}>
           <IconButton
@@ -92,7 +92,7 @@ export class AddTabButton extends React.Component<
             </Callout>
           )}
         </Stack>
-      </>
+      </div>
     );
   }
 

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
@@ -61,7 +61,7 @@ export class AddTabButton extends React.Component<
   public render(): React.ReactNode {
     const style = addTabButtonStyles();
     return (
-      <div style={style.buttonSection}>
+      <div className={style.buttonSection}>
         <div className={style.splitter} />
         <Stack horizontal horizontalAlign={"center"}>
           <IconButton

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
@@ -61,7 +61,7 @@ export class AddTabButton extends React.Component<
   public render(): React.ReactNode {
     const style = addTabButtonStyles();
     return (
-      <div style={{padding: "10px 0 10px 0"}}>
+      <div style={{ padding: "10px 0 10px 0" }}>
         <div className={style.splitter} />
         <Stack horizontal horizontalAlign={"center"}>
           <IconButton

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
@@ -61,7 +61,7 @@ export class AddTabButton extends React.Component<
   public render(): React.ReactNode {
     const style = addTabButtonStyles();
     return (
-      <div style={{ padding: "10px 0 10px 0" }}>
+      <div style={style.buttonSection}>
         <div className={style.splitter} />
         <Stack horizontal horizontalAlign={"center"}>
           <IconButton

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -25,7 +25,7 @@ import {
 import { ModelPerformanceTab } from "@responsible-ai/interpret";
 import { localization } from "@responsible-ai/localization";
 import _ from "lodash";
-import { Stack, Text } from "office-ui-fabric-react";
+import { DefaultEffects, Stack, Text } from "office-ui-fabric-react";
 import * as React from "react";
 
 import { AddTabButton } from "./AddTabButton";
@@ -104,8 +104,11 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
               }));
             }}
           />
-          <Stack>
-            <Stack.Item className={modelAssessmentDashboardStyles.section}>
+          <Stack tokens={{ childrenGap: "10px", padding: "10px 0 0 0" }}>
+            <Stack.Item
+              className={modelAssessmentDashboardStyles.section}
+              styles={{ root: { boxShadow: DefaultEffects.elevation4 } }}
+            >
               <CohortInfoSection
                 toggleShiftCohortVisibility={(): void => {
                   this.setState((prev) => ({
@@ -132,6 +135,7 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
                 <Stack.Item
                   key={i}
                   className={modelAssessmentDashboardStyles.section}
+                  styles={{ root: { boxShadow: DefaultEffects.elevation4 } }}
                 >
                   {t.key === GlobalTabKeys.ErrorAnalysisTab &&
                     this.props.errorAnalysisConfig?.[0] && (


### PR DESCRIPTION
Example screenshot:
![image](https://user-images.githubusercontent.com/10245648/121413975-15161200-c91b-11eb-95b3-7a14210917a2.png)


closes #526 