### PR TITLE
add tests for regression scenario in error analysis and fix issues in matrix filter

### DIFF
--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -11,7 +11,7 @@ from erroranalysis._internal.matrix_filter import compute_json_matrix
 from erroranalysis._internal.surrogate_error_tree import (
     compute_json_error_tree)
 from erroranalysis._internal.error_report import ErrorReport
-from erroranalysis._internal.constants import ModelTask
+from erroranalysis._internal.constants import ModelTask, Metrics
 
 
 class BaseAnalyzer(ABC):
@@ -32,6 +32,12 @@ class BaseAnalyzer(ABC):
         self._categorical_indexes = []
         self._category_dictionary = {}
         self._model_task = model_task
+        if model_task == ModelTask.CLASSIFICATION:
+            if metric is None:
+                metric = Metrics.ERROR_RATE
+        else:
+            if metric is None:
+                metric = Metrics.MEAN_SQUARED_ERROR
         self._metric = metric
         if self._categorical_features:
             self._categorical_indexes = [feature_names.index(feature)

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -55,18 +55,10 @@ def compute_json_error_tree(analyzer,
     if num_leaves is None:
         num_leaves = DEFAULT_NUM_LEAVES
     if analyzer.model_task == ModelTask.CLASSIFICATION:
-        if analyzer.metric is None:
-            metric = Metrics.ERROR_RATE
-        else:
-            metric = analyzer.metric
         surrogate = LGBMClassifier(n_estimators=1,
                                    max_depth=max_depth,
                                    num_leaves=num_leaves)
     else:
-        if analyzer.metric is None:
-            metric = Metrics.MEAN_SQUARED_ERROR
-        else:
-            metric = analyzer.metric
         surrogate = LGBMRegressor(n_estimators=1,
                                   max_depth=max_depth,
                                   num_leaves=num_leaves)
@@ -108,6 +100,10 @@ def compute_json_error_tree(analyzer,
         diff = pred_y - true_y
     if not isinstance(diff, np.ndarray):
         diff = np.array(diff)
+    if not isinstance(pred_y, np.ndarray):
+        pred_y = np.array(pred_y)
+    if not isinstance(true_y, np.ndarray):
+        true_y = np.array(true_y)
     indexes = []
     for feature in features:
         indexes.append(analyzer.feature_names.index(feature))
@@ -149,7 +145,7 @@ def compute_json_error_tree(analyzer,
                           cat_ind_reindexed),
                          [],
                          dataset_sub_names,
-                         metric=metric)
+                         metric=analyzer.metric)
     return json_tree
 
 

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '4'
+_patch = '5'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -6,8 +6,9 @@ import numpy as np
 import pandas as pd
 from sklearn import svm
 from sklearn.compose import ColumnTransformer
-from sklearn.datasets import load_iris, load_breast_cancer, make_classification
-from sklearn.ensemble import RandomForestClassifier
+from sklearn.datasets import (
+    load_boston, load_breast_cancer, load_iris, make_classification)
+from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import train_test_split
@@ -54,6 +55,13 @@ def create_sklearn_logistic_regressor(X, y, pipeline=False):
     if pipeline:
         lin = Pipeline([('lin', lin)])
     model = lin.fit(X, y)
+    return model
+
+
+def create_sklearn_random_forest_regressor(X, y):
+    rfc = RandomForestRegressor(n_estimators=10, max_depth=4,
+                                random_state=777)
+    model = rfc.fit(X, y)
     return model
 
 
@@ -115,7 +123,17 @@ def create_simple_titanic_data():
     return X_train, X_test, y_train, y_test, num_features, cat_features
 
 
-def create_models(X_train, y_train):
+def create_boston_data():
+    # Import Boston housing dataset
+    boston = load_boston()
+    # Split data into train and test
+    X_train, X_test, y_train, y_validation = train_test_split(
+        boston.data, boston.target,
+        test_size=0.2, random_state=7)
+    return X_train, X_test, y_train, y_validation, boston.feature_names
+
+
+def create_models_classification(X_train, y_train):
     svm_model = create_sklearn_svm_classifier(X_train, y_train)
     log_reg_model = create_sklearn_logistic_regressor(X_train, y_train)
     xgboost_model = create_xgboost_classifier(X_train, y_train)
@@ -123,6 +141,12 @@ def create_models(X_train, y_train):
     rf_model = create_sklearn_random_forest_classifier(X_train, y_train)
 
     return [svm_model, log_reg_model, xgboost_model, lgbm_model, rf_model]
+
+
+def create_models_regression(X_train, y_train):
+    rf_model = create_sklearn_random_forest_regressor(X_train, y_train)
+
+    return [rf_model]
 
 
 def create_titanic_pipeline(X_train, y_train):

--- a/erroranalysis/tests/test_importances.py
+++ b/erroranalysis/tests/test_importances.py
@@ -2,8 +2,10 @@
 # Licensed under the MIT License.
 
 from common_utils import (
-    create_iris_data, create_cancer_data, create_binary_classification_dataset,
-    create_models, create_simple_titanic_data, create_titanic_pipeline)
+    create_iris_data, create_cancer_data,
+    create_binary_classification_dataset,
+    create_models_classification, create_simple_titanic_data,
+    create_titanic_pipeline)
 from erroranalysis._internal.error_analyzer import ModelAnalyzer
 
 TOL = 1e-10
@@ -14,7 +16,7 @@ class TestImportances(object):
     def test_importances_iris(self):
         X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
 
-        models = create_models(X_train, y_train)
+        models = create_models_classification(X_train, y_train)
 
         for model in models:
             categorical_features = []
@@ -25,7 +27,7 @@ class TestImportances(object):
         X_train, X_test, y_train, y_test, feature_names, _ = \
             create_cancer_data()
 
-        models = create_models(X_train, y_train)
+        models = create_models_classification(X_train, y_train)
 
         for model in models:
             categorical_features = []
@@ -36,7 +38,7 @@ class TestImportances(object):
         X_train, y_train, X_test, y_test, _ = \
             create_binary_classification_dataset()
         feature_names = list(X_train.columns)
-        models = create_models(X_train, y_train)
+        models = create_models_classification(X_train, y_train)
 
         for model in models:
             categorical_features = []

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -1,14 +1,23 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import pandas as pd
 from erroranalysis._internal.error_analyzer import ModelAnalyzer
 from erroranalysis._internal.matrix_filter import (
-    CATEGORY1, CATEGORY2, COUNT, FALSE_COUNT, MATRIX, VALUES)
+    CATEGORY1, CATEGORY2, COUNT, FALSE_COUNT, MATRIX,
+    VALUES, METRIC_NAME, METRIC_VALUE)
+from erroranalysis._internal.cohort_filter import filter_from_cohort
 from common_utils import (
-    create_iris_data, create_cancer_data, create_simple_titanic_data,
-    create_titanic_pipeline, create_binary_classification_dataset,
-    create_models)
-from erroranalysis._internal.constants import ModelTask
+    create_boston_data, create_iris_data, create_cancer_data,
+    create_simple_titanic_data, create_titanic_pipeline,
+    create_binary_classification_dataset,
+    create_models_classification,
+    create_models_regression)
+from erroranalysis._internal.constants import (
+    ModelTask, TRUE_Y, ROW_INDEX, Metrics, metric_to_display_name)
+from erroranalysis._internal.metrics import metric_to_func
+
+TOLERANCE = 1e-5
 
 
 class TestMatrixFilter(object):
@@ -16,37 +25,91 @@ class TestMatrixFilter(object):
     def test_matrix_filter_iris(self):
         X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
 
-        models = create_models(X_train, y_train)
+        model_task = ModelTask.CLASSIFICATION
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names, model_task)
 
-        for model in models:
-            categorical_features = []
-            run_error_analyzer(model, X_test, y_test, feature_names,
-                               categorical_features,
-                               model_task=ModelTask.CLASSIFICATION)
+    def test_matrix_filter_iris_filters(self):
+        # Validate the shift cohort functionality where base
+        # cohort was chosen in tree view
+        X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
+
+        filters = [{'arg': [2.85],
+                    'column': feature_names[1],
+                    'method': 'less and equal'}]
+
+        model_task = ModelTask.CLASSIFICATION
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names,
+                                     model_task, filters=filters)
+
+    def test_matrix_filter_iris_filters_pandas(self):
+        # Validate the shift cohort functionality where base
+        # cohort was chosen in tree view
+        X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
+
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
+
+        filters = [{'arg': [2.85],
+                    'column': feature_names[1],
+                    'method': 'less and equal'}]
+
+        model_task = ModelTask.CLASSIFICATION
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names,
+                                     model_task, filters=filters)
 
     def test_matrix_filter_cancer(self):
         X_train, X_test, y_train, y_test, feature_names, _ = \
             create_cancer_data()
 
-        models = create_models(X_train, y_train)
+        model_task = ModelTask.CLASSIFICATION
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names,
+                                     model_task)
 
-        for model in models:
-            categorical_features = []
-            run_error_analyzer(model, X_test, y_test, feature_names,
-                               categorical_features,
-                               model_task=ModelTask.CLASSIFICATION)
+    def test_matrix_filter_cancer_filters(self):
+        # Validate the shift cohort functionality where base
+        # cohort was chosen in matrix view
+        X_train, X_test, y_train, y_test, feature_names, _ = \
+            create_cancer_data()
+
+        composite_filters = [{'compositeFilters':
+                             [{'compositeFilters':
+                              [{'arg': [11.364, 13.182],
+                                'column': 'mean radius',
+                                'method': 'in the range of'}],
+                               'operation': 'and'},
+                              {'compositeFilters':
+                               [{'arg': [13.182, 15],
+                                 'column': 'mean radius',
+                                 'method': 'in the range of'}],
+                               'operation': 'and'},
+                              {'compositeFilters':
+                               [{'arg': [15, 16.817],
+                                 'column': 'mean radius',
+                                 'method': 'in the range of'}],
+                               'operation': 'and'},
+                              {'compositeFilters':
+                               [{'arg': [16.817, 18.635],
+                                 'column': 'mean radius',
+                                 'method': 'in the range of'}],
+                               'operation': 'and'}],
+                             'operation': 'or'}]
+
+        model_task = ModelTask.CLASSIFICATION
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names, model_task,
+                                     composite_filters=composite_filters)
 
     def test_matrix_filter_binary_classification(self):
         X_train, y_train, X_test, y_test, _ = \
             create_binary_classification_dataset()
         feature_names = list(X_train.columns)
-        models = create_models(X_train, y_train)
-
-        for model in models:
-            categorical_features = []
-            run_error_analyzer(model, X_test, y_test, feature_names,
-                               categorical_features,
-                               model_task=ModelTask.CLASSIFICATION)
+        model_task = ModelTask.CLASSIFICATION
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names, model_task)
 
     def test_matrix_filter_titanic(self):
         X_train, X_test, y_train, y_test, numeric, categorical = \
@@ -58,13 +121,58 @@ class TestMatrixFilter(object):
                            categorical_features,
                            model_task=ModelTask.CLASSIFICATION)
 
+    def test_matrix_filter_boston(self):
+        X_train, X_test, y_train, y_test, feature_names = create_boston_data()
+
+        model_task = ModelTask.REGRESSION
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names, model_task)
+
+    def test_matrix_filter_boston_filters(self):
+        X_train, X_test, y_train, y_test, feature_names = create_boston_data()
+
+        filters = [{'arg': [0.675],
+                    'column': 'NOX',
+                    'method': 'less and equal'},
+                   {'arg': [7.141000000000001],
+                    'column': 'RM',
+                    'method': 'greater'}]
+
+        model_task = ModelTask.REGRESSION
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names,
+                                     model_task, filters=filters)
+
+
+def run_error_analyzer_on_models(X_train,
+                                 y_train,
+                                 X_test,
+                                 y_test,
+                                 feature_names,
+                                 model_task,
+                                 filters=None,
+                                 composite_filters=None):
+    if model_task == ModelTask.CLASSIFICATION:
+        models = create_models_classification(X_train, y_train)
+    else:
+        models = create_models_regression(X_train, y_train)
+
+    for model in models:
+        categorical_features = []
+        run_error_analyzer(model, X_test, y_test, feature_names,
+                           categorical_features, model_task=model_task,
+                           filters=filters,
+                           composite_filters=composite_filters)
+
 
 def run_error_analyzer(model,
                        X_test,
                        y_test,
                        feature_names,
                        categorical_features,
-                       model_task):
+                       model_task,
+                       filters=None,
+                       composite_filters=None):
     error_analyzer = ModelAnalyzer(model,
                                    X_test,
                                    y_test,
@@ -73,16 +181,40 @@ def run_error_analyzer(model,
                                    model_task=model_task)
     # features, filters, composite_filters
     features = [feature_names[0], feature_names[1]]
-    filters = None
-    composite_filters = None
     json_matrix = error_analyzer.compute_matrix(features, filters,
                                                 composite_filters)
-    expected_count = len(X_test)
-    expected_false_count = sum(model.predict(X_test) != y_test)
-    validate_matrix(json_matrix, expected_count, expected_false_count)
+    validation_data = X_test
+    if filters is not None or composite_filters is not None:
+        validation_data = filter_from_cohort(X_test,
+                                             filters,
+                                             composite_filters,
+                                             feature_names,
+                                             y_test,
+                                             categorical_features,
+                                             error_analyzer.categories)
+        y_test = validation_data[TRUE_Y]
+        validation_data = validation_data.drop(columns=[TRUE_Y, ROW_INDEX])
+        if not isinstance(X_test, pd.DataFrame):
+            validation_data = validation_data.values
+    expected_count = len(validation_data)
+    metric = error_analyzer.metric
+    if metric == Metrics.ERROR_RATE:
+        expected_error = sum(model.predict(validation_data) != y_test)
+    elif metric == Metrics.MEAN_SQUARED_ERROR:
+        func = metric_to_func[metric]
+        expected_error = func(model.predict(validation_data), y_test)
+    else:
+        raise NotImplementedError(
+            "Metric {} validation not supported yet".format(metric))
+    validate_matrix(json_matrix,
+                    expected_count,
+                    expected_error,
+                    metric=metric)
 
 
-def validate_matrix(json_matrix, exp_total_count, exp_total_false_count):
+def validate_matrix(json_matrix, exp_total_count,
+                    exp_total_error,
+                    metric=Metrics.ERROR_RATE):
     assert MATRIX in json_matrix
     assert CATEGORY1 in json_matrix
     assert CATEGORY2 in json_matrix
@@ -90,12 +222,39 @@ def validate_matrix(json_matrix, exp_total_count, exp_total_false_count):
     num_cat2 = len(json_matrix[CATEGORY2][VALUES])
     assert len(json_matrix[MATRIX]) == num_cat1
     assert len(json_matrix[MATRIX][0]) == num_cat2
-    # take sum of count, false count
-    total_count = 0
-    total_false_count = 0
-    for i in range(num_cat1):
-        for j in range(num_cat2):
-            total_count += json_matrix[MATRIX][i][j][COUNT]
-            total_false_count += json_matrix[MATRIX][i][j][FALSE_COUNT]
-    assert exp_total_count == total_count
-    assert exp_total_false_count == total_false_count
+    validate_matrix_metric(json_matrix, exp_total_count,
+                           exp_total_error, metric,
+                           num_cat1, num_cat2)
+
+
+def validate_matrix_metric(json_matrix, exp_total_count,
+                           exp_total_error, metric,
+                           num_cat1, num_cat2):
+    if metric == Metrics.ERROR_RATE:
+        # take sum of count, false count
+        total_count = 0
+        total_false_count = 0
+        for i in range(num_cat1):
+            for j in range(num_cat2):
+                total_count += json_matrix[MATRIX][i][j][COUNT]
+                total_false_count += json_matrix[MATRIX][i][j][FALSE_COUNT]
+        assert exp_total_count == total_count
+        assert exp_total_error == total_false_count
+    elif metric == Metrics.MEAN_SQUARED_ERROR:
+        # take sum of count, metric value
+        total_count = 0
+        total_metric_value = 0
+        for i in range(num_cat1):
+            for j in range(num_cat2):
+                count = json_matrix[MATRIX][i][j][COUNT]
+                total_count += count
+                cell_value = json_matrix[MATRIX][i][j][METRIC_VALUE] * count
+                total_metric_value += cell_value
+                metric_name = json_matrix[MATRIX][i][j][METRIC_NAME]
+                assert metric_name == metric_to_display_name[metric]
+        total_metric_value = total_metric_value / total_count
+        assert exp_total_count == total_count
+        assert abs(exp_total_error - total_metric_value) < TOLERANCE
+    else:
+        raise NotImplementedError(
+            "Metric {} validation not supported yet".format(metric))

--- a/erroranalysis/tests/test_surrogate_error_tree.py
+++ b/erroranalysis/tests/test_surrogate_error_tree.py
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
-from common_utils import create_iris_data, create_models
+from common_utils import create_iris_data, create_models_classification
 from erroranalysis._internal.error_analyzer import ModelAnalyzer
 
 SIZE = 'size'
@@ -15,7 +15,7 @@ class TestSurrogateErrorTree(object):
     def test_surrogate_error_tree_iris(self):
         X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
 
-        models = create_models(X_train, y_train)
+        models = create_models_classification(X_train, y_train)
 
         for model in models:
             categorical_features = []


### PR DESCRIPTION
- add several tests for 1.) regression scenario 2.) filters
- refactors some of the common test code
- fix two issues in the matrix filter:
  - when specifying filters, metric calculation fails due to pred_y/true_y being pandas dataframes
  - the total counts matrix was incorrect for regression scenario, it was actually showing rounded total error