### PR TITLE
in error analysis fix toFixed error in matrix filter for zero metric values

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixArea.tsx
@@ -185,7 +185,7 @@ export class MatrixArea extends React.PureComponent<
     let maxMetricValue = 0;
     jsonMatrix.matrix.forEach((row: any): void => {
       row.forEach((value: any): void => {
-        if (value.falseCount) {
+        if (value.falseCount !== undefined) {
           const errorRate = value.falseCount / value.count;
           if (!Number.isNaN(errorRate)) {
             maxMetricValue = Math.max(maxMetricValue, errorRate);

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixAreaUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixAreaUtils.ts
@@ -83,9 +83,9 @@ export function createCohortStatsFromSelectedCells(
   jsonMatrix.matrix.forEach((row: any, i: number) => {
     row.forEach((value: any, j: number) => {
       if (selectedCells !== undefined && selectedCells[j + i * row.length]) {
-        if (value.falseCount) {
+        if (value.falseCount !== undefined) {
           falseCohortCount += value.falseCount;
-        } else if (value.metricValue) {
+        } else if (value.metricValue !== undefined) {
           metricName = value.metricName;
           if (value.metricName === Metrics.MeanSquaredError) {
             totalCohortError += value.metricValue * value.count;
@@ -94,9 +94,9 @@ export function createCohortStatsFromSelectedCells(
         totalCohortCount += value.count;
         existsSelectedCell = true;
       }
-      if (value.falseCount) {
+      if (value.falseCount !== undefined) {
         falseCount += value.falseCount;
-      } else if (value.metricValue) {
+      } else if (value.metricValue !== undefined) {
         metricName = value.metricName;
         if (value.metricName === Metrics.MeanSquaredError) {
           totalError += value.metricValue * value.count;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixCells/MatrixCells.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixCells/MatrixCells.tsx
@@ -51,9 +51,9 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
     let metricName: string;
     this.props.jsonMatrix.matrix.forEach((row: any) => {
       row.forEach((value: any) => {
-        if (value.falseCount) {
+        if (value.falseCount !== undefined) {
           falseCount += value.falseCount;
-        } else if (value.metricValue) {
+        } else if (value.metricValue !== undefined) {
           metricName = value.metricName;
           if (value.metricName === Metrics.MeanSquaredError) {
             totalError += value.metricValue * value.count;
@@ -69,7 +69,7 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
           let errorRatio = 0;
           let styledGradientMatrixCell: IStyle = classNames.styledMatrixCell;
           if (value.count > 0) {
-            if (value.falseCount) {
+            if (value.falseCount !== undefined) {
               errorRatio = (value.falseCount / value.count) * 100;
             } else {
               metricName = value.metricName;
@@ -104,7 +104,7 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
           let error: number;
           let baseError: number;
           let metricValue: number;
-          if (value.falseCount) {
+          if (value.falseCount !== undefined) {
             metricValue = errorRatio;
             error = value.falseCount;
             baseError = falseCount;


### PR DESCRIPTION
matrix filter in error analysis crashed on cells with zero values for falseCount in classification scenario.  Fixing this as the check should be against !== undefined instead of boolean check (which misses zero values in typescript)