### PR TITLE
Update interpret-community version

### DIFF
--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,7 +1,7 @@
 dice-ml>=0.6.1,<0.7
 econml>=0.12.0b1
 erroranalysis>=0.1.4
-interpret-community>=0.17.0
+interpret-community>=0.18.1
 lightgbm>=2.0.11
 numpy>=1.17.2
 pandas>=0.25.1


### PR DESCRIPTION
Upgrade the interpret community version to 1.18.* range to get newest changes in sparse support and latest shap compatibility