### PR TITLE
Add serialization for causal analysis

### DIFF
--- a/raiwidgets/raiwidgets/dashboard.py
+++ b/raiwidgets/raiwidgets/dashboard.py
@@ -3,12 +3,14 @@
 
 """Defines the dashboard class."""
 
-from rai_core_flask import FlaskHelper  # , environment_detector
 import json
 import os
-from html.parser import HTMLParser
 import uuid
-from responsibleai._input_processing import _safe_object_serializer
+
+from html.parser import HTMLParser
+from rai_core_flask import FlaskHelper  # , environment_detector
+
+from responsibleai.serialization_utilities import serialize_json_safe
 
 
 class InLineScript(HTMLParser):
@@ -106,7 +108,7 @@ class Dashboard(object):
             content = content.replace(
                 "__rai_model_data__",
                 json.dumps(self.model_data,
-                           default=_safe_object_serializer))
+                           default=serialize_json_safe))
             return content
 
     def add_url_rule(self, func, route, methods):

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -10,7 +10,7 @@ import pandas as pd
 import traceback
 from .constants import ModelTask, SKLearn
 from .error_handling import _format_exception
-from responsibleai._input_processing import _serialize_json_safe
+from responsibleai.serialization_utilities import serialize_json_safe
 from erroranalysis._internal.error_analyzer import (
     ModelAnalyzer, PredictionsAnalyzer)
 from erroranalysis._internal.metrics import metric_to_func
@@ -182,7 +182,7 @@ class ErrorAnalysisDashboardInput:
                                  " dataset.")
             self.dashboard_input[
                 ExplanationDashboardInterface.TRAINING_DATA
-            ] = _serialize_json_safe(list_dataset)
+            ] = serialize_json_safe(list_dataset)
             self.dashboard_input[
                 ExplanationDashboardInterface.IS_CLASSIFIER
             ] = self._is_classifier

--- a/raiwidgets/raiwidgets/explanation_dashboard_input.py
+++ b/raiwidgets/raiwidgets/explanation_dashboard_input.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from .constants import SKLearn
 from .error_handling import _format_exception
-from responsibleai._input_processing import _serialize_json_safe
+from responsibleai.serialization_utilities import serialize_json_safe
 
 
 class ExplanationDashboardInput:
@@ -128,7 +128,7 @@ class ExplanationDashboardInput:
                                  " dataset.")
             self.dashboard_input[
                 ExplanationDashboardInterface.TRAINING_DATA
-            ] = _serialize_json_safe(list_dataset)
+            ] = serialize_json_safe(list_dataset)
             self.dashboard_input[
                 ExplanationDashboardInterface.IS_CLASSIFIER
             ] = self._is_classifier

--- a/raiwidgets/tests/test_model_analysis_dashboard.py
+++ b/raiwidgets/tests/test_model_analysis_dashboard.py
@@ -12,22 +12,22 @@ from responsibleai._interfaces import CausalData, CounterfactualData, Dataset,\
 
 class TestModelAnalysisDashboard:
     def test_model_analysis_adult(self):
-        x, y = shap.datasets.adult()
+        X, y = shap.datasets.adult()
         y = [1 if r else 0 for r in y]
 
-        x, y = sklearn.utils.resample(
-            x, y, n_samples=1000, random_state=7, stratify=y)
+        X, y = sklearn.utils.resample(
+            X, y, n_samples=1000, random_state=7, stratify=y)
 
         X_train, X_test, y_train, y_test = train_test_split(
-            x, y, test_size=0.2, random_state=7, stratify=y)
+            X, y, test_size=0.2, random_state=7, stratify=y)
 
         knn = sklearn.neighbors.KNeighborsClassifier()
         knn.fit(X_train, y_train)
 
-        x["income"] = y
-        X_test["income"] = y_test
+        X['Income'] = y
+        X_test['Income'] = y_test
 
-        ma = ModelAnalysis(knn, x, X_test, "income", "classification",
+        ma = ModelAnalysis(knn, X, X_test, 'Income', 'classification',
                            categorical_features=['Workclass', 'Education-Num',
                                                  'Marital Status',
                                                  'Occupation', 'Relationship',
@@ -37,9 +37,12 @@ class TestModelAnalysisDashboard:
         ma.counterfactual.add(['Age',
                                'Capital Gain', 'Capital Loss',
                                'Hours per week'], 10,
-                              desired_class="opposite")
+                              desired_class='opposite')
         ma.error_analysis.add()
-        ma.causal.add()
+        ma.causal.add(treatment_features=['Hours per week', 'Occupation'],
+                      heterogeneity_features=None,
+                      upper_bound_on_cat_expansion=42,
+                      skip_cat_limit_checks=True)
         ma.compute()
 
         widget = ModelAnalysisDashboard(ma)

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,5 +1,5 @@
 dice-ml>=0.6.1,<0.7
-econml>=0.12.0b1
+econml>=0.12.0b2
 erroranalysis>=0.1.8
 interpret-community>=0.18.1
 lightgbm>=2.0.11

--- a/responsibleai/responsibleai/_input_processing.py
+++ b/responsibleai/responsibleai/_input_processing.py
@@ -6,7 +6,7 @@ import pandas as pd
 from scipy.sparse import issparse
 from sklearn.utils import check_consistent_length
 from typing import Dict, List
-import datetime
+
 
 _DF_COLUMN_BAD_NAME = "DataFrame column names must be strings."\
     " Name '{0}' is of type {1}"
@@ -104,37 +104,3 @@ def _convert_to_string_list_dict(
             raise ValueError(_TOO_MANY_DIMS)
 
     return result
-
-
-def _safe_object_serializer(o):
-    return _serialize_json_safe(o, for_object=True)
-
-
-def _serialize_json_safe(o, for_object=False):
-    """
-    Convert a value into something that is safe to parse into JSON.
-
-    :param o: Object to make JSON safe.
-    :return: New object
-    """
-    if type(o) in {int, float, str, type(None)}:
-        if isinstance(o, float):
-            if np.isinf(o) or np.isnan(o):
-                return 0
-        return o
-    elif isinstance(o, datetime.datetime):
-        return o.__str__()
-    elif isinstance(o, dict):
-        return {k: _serialize_json_safe(v) for k, v in o.items()}
-    elif isinstance(o, list):
-        return [_serialize_json_safe(v) for v in o]
-    elif isinstance(o, tuple):
-        return tuple(_serialize_json_safe(v) for v in o)
-    elif isinstance(o, np.ndarray):
-        return _serialize_json_safe(o.tolist())
-    else:
-        # Attempt to convert Numpy type
-        try:
-            return o.item()
-        except Exception:
-            return _serialize_json_safe(o.__dict__) if for_object else o

--- a/responsibleai/responsibleai/_input_processing.py
+++ b/responsibleai/responsibleai/_input_processing.py
@@ -137,4 +137,4 @@ def _serialize_json_safe(o, for_object=False):
         try:
             return o.item()
         except Exception:
-            return o.__dict__ if for_object else o
+            return _serialize_json_safe(o.__dict__) if for_object else o

--- a/responsibleai/responsibleai/_input_processing.py
+++ b/responsibleai/responsibleai/_input_processing.py
@@ -107,10 +107,10 @@ def _convert_to_string_list_dict(
 
 
 def _safe_object_serializer(o):
-    return _serialize_json_safe(o, True)
+    return _serialize_json_safe(o, for_object=True)
 
 
-def _serialize_json_safe(o, forObject=False):
+def _serialize_json_safe(o, for_object=False):
     """
     Convert a value into something that is safe to parse into JSON.
 
@@ -137,4 +137,4 @@ def _serialize_json_safe(o, forObject=False):
         try:
             return o.item()
         except Exception:
-            return o.__dict__ if forObject else o
+            return o.__dict__ if for_object else o

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import List, Tuple
+from typing import Dict, List, Tuple, Union
 
 
 class Dataset:
@@ -75,9 +75,36 @@ class CausalMetric:
     zstat: float
 
 
+class CausalPolicyGains:
+    recommended_policy_gains: float
+    treatment_gains: List[float]
+
+
+class CausalPolicyTreeLeaf:
+    leaf: bool
+    n_samples: int
+    treatment: str
+
+
+class CausalPolicyTreeInternal:
+    leaf: bool
+    feature: str
+    left: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
+    right: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
+    threshold: Union[float, str]  # TODO: Categorical features
+
+
+class CausalPolicy:
+    treatment_feature: str
+    local_policies: Dict[str, List[float]]
+    policy_tree: Union[CausalPolicyTreeInternal, CausalPolicyTreeLeaf]
+    policy_gains: CausalPolicyGains
+
+
 class CausalData:
     global_effects: List[CausalMetric]
     local_effects: List[List[CausalMetric]]
+    policies: List[CausalPolicy]
 
 
 class CounterfactualData:

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -89,16 +89,16 @@ class CausalPolicyTreeLeaf:
 class CausalPolicyTreeInternal:
     leaf: bool
     feature: str
+    threshold: Union[float, str]  # TODO: Categorical features
     left: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
     right: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
-    threshold: Union[float, str]  # TODO: Categorical features
 
 
 class CausalPolicy:
     treatment_feature: str
     local_policies: Dict[str, List[float]]
-    policy_tree: Union[CausalPolicyTreeInternal, CausalPolicyTreeLeaf]
     policy_gains: CausalPolicyGains
+    policy_tree: Union[CausalPolicyTreeInternal, CausalPolicyTreeLeaf]
 
 
 class CausalData:

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -28,6 +28,7 @@ class CausalConfig(BaseConfig):
     def __init__(
         self,
         treatment_features,
+        heterogeneity_features,
         nuisance_model,
         heterogeneity_model,
         alpha,
@@ -39,6 +40,7 @@ class CausalConfig(BaseConfig):
     ):
         super().__init__()
         self.treatment_features = treatment_features
+        self.heterogeneity_features = heterogeneity_features
         self.nuisance_model = nuisance_model
         self.heterogeneity_model = heterogeneity_model
         self.alpha = alpha
@@ -58,6 +60,8 @@ class CausalConfig(BaseConfig):
         return all([
             np.array_equal(self.treatment_features,
                            other.treatment_features),
+            np.array_equal(self.heterogeneity_features,
+                           other.heterogeneity_features),
             self.nuisance_model == other.nuisance_model,
             self.heterogeneity_model == other.heterogeneity_model,
             self.alpha == other.alpha,
@@ -71,6 +75,7 @@ class CausalConfig(BaseConfig):
     def __repr__(self):
         return ("CausalConfig("
                 f"treatment_features={self.treatment_features}, "
+                f"heterogeneity_features={self.heterogeneity_features}, "
                 f"nuisance_model={self.nuisance_model}, "
                 f"heterogeneity_model={self.heterogeneity_model}, "
                 f"alpha={self.alpha}, "
@@ -132,7 +137,8 @@ class CausalManager(BaseManager):
 
     def add(
         self,
-        treatment_features=None,
+        treatment_features,
+        heterogeneity_features=None,
         nuisance_model=CausalConstants.AUTOML,
         heterogeneity_model=None,
         alpha=0.05,
@@ -143,8 +149,10 @@ class CausalManager(BaseManager):
         skip_cat_limit_checks=False,
     ):
         """Add a causal configuration to be computed later.
-        :param treatment_features: All treatment feature names.
+        :param treatment_features: Treatment feature names.
         :type treatment_features: list
+        :param heterogeneity_features: Features that mediate the causal effect.
+        :type heterogeneity_features: list
         :param nuisance_model: Model type to use for nuisance estimation.
         :type nuisance_model: str
         :param heterogeneity_model: Model type to use for
@@ -170,7 +178,8 @@ class CausalManager(BaseManager):
         :type skip_cat_limit_checks: bool
         """
         causal_config = CausalConfig(
-            treatment_features=treatment_features,
+            treatment_features,
+            heterogeneity_features=heterogeneity_features,
             nuisance_model=nuisance_model,
             heterogeneity_model=heterogeneity_model,
             alpha=alpha,
@@ -208,9 +217,9 @@ class CausalManager(BaseManager):
                 self._target_column].values.ravel()
 
             analysis = CausalAnalysis(
-                X.columns.values.tolist(),
+                config.treatment_features,
                 self._categorical_features,
-                heterogeneity_inds=config.treatment_features,
+                heterogeneity_inds=config.heterogeneity_features,
                 classification=is_classification,
                 nuisance_models=config.nuisance_model,
                 upper_bound_on_cat_expansion=config.max_cat_expansion,

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -239,7 +239,6 @@ class CausalManager(BaseManager):
             config.policies = []
             if config.treatment_features is not None:
                 for treatment_feature in config.treatment_features:
-                    # TODO: Update to dataframe
                     local_policies = analysis.individualized_policy(
                         X_test, treatment_feature,
                         treatment_costs=config.treatment_cost,

--- a/responsibleai/responsibleai/serialization_utilities.py
+++ b/responsibleai/responsibleai/serialization_utilities.py
@@ -29,9 +29,9 @@ def serialize_json_safe(o: Any):
         return tuple(serialize_json_safe(v) for v in o)
     elif isinstance(o, np.ndarray):
         return serialize_json_safe(o.tolist())
+    elif hasattr(o, 'item'):
+        return o.item()  # numpy types
+    elif hasattr(o, '__dict__'):
+        return serialize_json_safe(o.__dict__)  # objects
     else:
-        # Attempt to convert Numpy type
-        try:
-            return o.item()
-        except Exception:
-            return serialize_json_safe(o.__dict__)
+        return o

--- a/responsibleai/responsibleai/serialization_utilities.py
+++ b/responsibleai/responsibleai/serialization_utilities.py
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import datetime
+import numpy as np
+
+from typing import Any
+
+
+def serialize_json_safe(o: Any):
+    """
+    Convert a value into something that is safe to parse into JSON.
+
+    :param o: Object to make JSON safe.
+    :return: Serialized object.
+    """
+    if type(o) in {bool, int, float, str, type(None)}:
+        if isinstance(o, float):
+            if np.isinf(o) or np.isnan(o):
+                return 0
+        return o
+    elif isinstance(o, datetime.datetime):
+        return o.__str__()
+    elif isinstance(o, dict):
+        return {k: serialize_json_safe(v, ) for k, v in o.items()}
+    elif isinstance(o, list):
+        return [serialize_json_safe(v) for v in o]
+    elif isinstance(o, tuple):
+        return tuple(serialize_json_safe(v) for v in o)
+    elif isinstance(o, np.ndarray):
+        return serialize_json_safe(o.tolist())
+    else:
+        # Attempt to convert Numpy type
+        try:
+            return o.item()
+        except Exception:
+            return serialize_json_safe(o.__dict__)

--- a/responsibleai/tests/causal_manager_validator.py
+++ b/responsibleai/tests/causal_manager_validator.py
@@ -149,10 +149,14 @@ def _check_policy(policy, is_serialized=False):
 
 
 def _check_treatment_feature(treatment_feature):
-    assert isinstance(treatment_feature, str)
+    pass
 
 
 def _check_local_policies(local_policies, is_serialized=False):
+    # Required for individualized_policy bug in EconML version 0.12.0b2
+    if local_policies is None:
+        return
+
     if is_serialized:
         assert isinstance(local_policies, list)
     else:

--- a/responsibleai/tests/causal_manager_validator.py
+++ b/responsibleai/tests/causal_manager_validator.py
@@ -57,12 +57,13 @@ def validate_causal(model_analysis, data, target_column,
     # Add a duplicate configuration
     message = "Duplicate causal configuration detected."
     with pytest.raises(DuplicateManagerConfigException, match=message):
-        model_analysis.causal.add(nuisance_model='automl',
-                                  treatment_features=treatment_features,
+        model_analysis.causal.add(treatment_features,
+                                  nuisance_model='automl',
                                   max_cat_expansion=max_cat_expansion)
 
     # Add the second configuration
-    model_analysis.causal.add(nuisance_model='linear')
+    model_analysis.causal.add(treatment_features,
+                              nuisance_model='linear')
     model_analysis.causal.compute()
     results = model_analysis.causal.get()
     assert results is not None
@@ -70,7 +71,8 @@ def validate_causal(model_analysis, data, target_column,
     assert len(results) == 2
 
     # Add a bad configuration
-    model_analysis.causal.add(nuisance_model='fake_model')
+    model_analysis.causal.add(treatment_features,
+                              nuisance_model='fake_model')
     with pytest.raises(UserConfigValidationException):
         model_analysis.causal.compute()
 

--- a/responsibleai/tests/causal_manager_validator.py
+++ b/responsibleai/tests/causal_manager_validator.py
@@ -37,9 +37,10 @@ LOCAL_POLICY_ATTRIBUTES = [
 def validate_causal(model_analysis, data, target_column,
                     treatment_features, max_cat_expansion):
     # Add the first configuration
-    model_analysis.causal.add(nuisance_model='automl',
-                              treatment_features=treatment_features,
-                              max_cat_expansion=max_cat_expansion)
+    model_analysis.causal.add(
+        treatment_features,
+        nuisance_model='automl',
+        upper_bound_on_cat_expansion=max_cat_expansion)
     model_analysis.causal.compute()
 
     results = model_analysis.causal.get()
@@ -57,9 +58,10 @@ def validate_causal(model_analysis, data, target_column,
     # Add a duplicate configuration
     message = "Duplicate causal configuration detected."
     with pytest.raises(DuplicateManagerConfigException, match=message):
-        model_analysis.causal.add(treatment_features,
-                                  nuisance_model='automl',
-                                  max_cat_expansion=max_cat_expansion)
+        model_analysis.causal.add(
+            treatment_features,
+            nuisance_model='automl',
+            upper_bound_on_cat_expansion=max_cat_expansion)
 
     # Add the second configuration
     model_analysis.causal.add(treatment_features,

--- a/responsibleai/tests/causal_manager_validator.py
+++ b/responsibleai/tests/causal_manager_validator.py
@@ -9,25 +9,20 @@ from responsibleai.exceptions import (
     DuplicateManagerConfigException,
     UserConfigValidationException)
 
+from responsibleai._interfaces import (
+    CausalData, CausalPolicy, CausalPolicyGains,
+    CausalPolicyTreeInternal, CausalPolicyTreeLeaf)
+
 from econml.solutions.causal_analysis._causal_analysis import CausalAnalysis
 
 
 EFFECTS_ATTRIBUTES = [
-    # 'raw_name',
-    # 'name',
-    # 'cat',
-    # 'type',
-    # 'version',
-    # 'causal_computation_type',
-    # 'confounding_interval',
-    # 'init_args',
     'point',
     'stderr',
     'zstat',
     'ci_lower',
     'ci_upper',
     'p_value',
-    # 'view',
 ]
 
 LOCAL_POLICY_ATTRIBUTES = [
@@ -46,12 +41,18 @@ def validate_causal(model_analysis, data, target_column,
                               treatment_features=treatment_features,
                               max_cat_expansion=max_cat_expansion)
     model_analysis.causal.compute()
+
     results = model_analysis.causal.get()
     assert results is not None
     assert isinstance(results, list)
     assert len(results) == 1
-    causal_results = results[0]
-    _check_causal_results(causal_results)
+    _check_causal_results(results[0])
+
+    results = model_analysis.causal.get_data()
+    assert results is not None
+    assert isinstance(results, list)
+    assert len(results) == 1
+    _check_causal_results(results[0], is_serialized=True)
 
     # Add a duplicate configuration
     message = "Duplicate causal configuration detected."
@@ -74,84 +75,125 @@ def validate_causal(model_analysis, data, target_column,
         model_analysis.causal.compute()
 
 
-def _check_causal_results(causal_results):
-    assert isinstance(causal_results, dict)
-    assert len(causal_results) == 4
+def _check_causal_results(causal_results, is_serialized=False):
+    if is_serialized:
+        assert isinstance(causal_results, CausalData)
+        assert len(causal_results.__dict__) == 3
+        global_effects = causal_results.global_effects
+        local_effects = causal_results.local_effects
+        policies = causal_results.policies
+    else:
+        assert isinstance(causal_results, dict)
+        assert len(causal_results) == 4
+        global_effects = causal_results['global_effects']
+        local_effects = causal_results['local_effects']
+        policies = causal_results['policies']
 
-    assert 'causal_analysis' in causal_results
-    _check_causal_analysis(causal_results['causal_analysis'])
-    assert 'global_effects' in causal_results
-    _check_global_effects(causal_results['global_effects'])
-    assert 'local_effects' in causal_results
-    _check_local_effects(causal_results['local_effects'])
-    assert 'policies' in causal_results
-    _check_policies(causal_results['policies'])
+        _check_causal_analysis(causal_results['causal_analysis'])
+
+    _check_global_effects(global_effects, is_serialized=is_serialized)
+    _check_local_effects(local_effects, is_serialized=is_serialized)
+    _check_policies(policies, is_serialized=is_serialized)
 
 
 def _check_causal_analysis(causal_analysis):
     assert isinstance(causal_analysis, CausalAnalysis)
 
 
-def _check_global_effects(global_effects):
-    assert isinstance(global_effects, pd.DataFrame)
-    for attribute in EFFECTS_ATTRIBUTES:
-        assert attribute in global_effects.columns.to_list()
+def _check_global_effects(global_effects, is_serialized=False):
+    if is_serialized:
+        assert isinstance(global_effects, list)
+    else:
+        assert isinstance(global_effects, pd.DataFrame)
+        for attribute in EFFECTS_ATTRIBUTES:
+            assert attribute in global_effects.columns.to_list()
 
 
-def _check_local_effects(local_effects):
-    assert isinstance(local_effects, pd.DataFrame)
-    for attribute in EFFECTS_ATTRIBUTES:
-        assert attribute in local_effects.columns.to_list()
+def _check_local_effects(local_effects, is_serialized=False):
+    if is_serialized:
+        assert isinstance(local_effects, list)
+    else:
+        assert isinstance(local_effects, pd.DataFrame)
+        for attribute in EFFECTS_ATTRIBUTES:
+            assert attribute in local_effects.columns.to_list()
 
 
-def _check_policies(policies):
+def _check_policies(policies, is_serialized=False):
     assert isinstance(policies, list)
     for policy in policies:
-        _check_policy(policy)
+        _check_policy(policy, is_serialized=is_serialized)
 
 
-def _check_policy(policy):
-    assert isinstance(policy, dict)
+def _check_policy(policy, is_serialized=False):
+    if is_serialized:
+        assert isinstance(policy, CausalPolicy)
+        treatment_feature = policy.treatment_feature
+        local_policies = policy.local_policies
+        policy_gains = policy.policy_gains
+        policy_tree = policy.policy_tree
+    else:
+        assert isinstance(policy, dict)
+        treatment_feature = policy['treatment_feature']
+        local_policies = policy['local_policies']
+        policy_gains = policy['policy_gains']
+        policy_tree = policy['policy_tree']
 
-    assert 'local_policies' in policy
-    local_policies = policy['local_policies']
-    assert isinstance(local_policies, dict)
-    for attribute in LOCAL_POLICY_ATTRIBUTES:
-        assert attribute in local_policies
+    _check_treatment_feature(treatment_feature)
+    _check_local_policies(local_policies, is_serialized=is_serialized)
+    _check_policy_gains(policy_gains, is_serialized=is_serialized)
+    _check_policy_tree(policy_tree, is_serialized=is_serialized)
 
-    assert 'policy_tree' in policy
-    policy_tree = policy['policy_tree']
-    _check_policy_tree(policy_tree)
 
-    assert 'policy_gains' in policy
-    policy_gains = policy['policy_gains']
-    assert isinstance(policy_gains, dict)
+def _check_treatment_feature(treatment_feature):
+    assert isinstance(treatment_feature, str)
 
-    assert 'recommended_policy_gains' in policy_gains
-    recommended_policy_gains = policy_gains['recommended_policy_gains']
+
+def _check_local_policies(local_policies, is_serialized=False):
+    if is_serialized:
+        assert isinstance(local_policies, list)
+    else:
+        assert isinstance(local_policies, pd.DataFrame)
+
+
+def _check_policy_gains(policy_gains, is_serialized=False):
+    if is_serialized:
+        assert isinstance(policy_gains, CausalPolicyGains)
+        recommended_policy_gains = policy_gains.recommended_policy_gains
+        treatment_gains = policy_gains.treatment_gains
+    else:
+        assert isinstance(policy_gains, dict)
+        recommended_policy_gains = policy_gains['recommended_policy_gains']
+        treatment_gains = policy_gains['treatment_gains']
+
     assert isinstance(recommended_policy_gains, float)
 
-    assert 'treatment_gains' in policy_gains
-    treatment_gains = policy_gains['treatment_gains']
     assert isinstance(treatment_gains, list)
     assert all(isinstance(v, float) for v in treatment_gains)
 
 
-def _check_policy_tree(policy_tree):
-    assert 'leaf' in policy_tree
-    leaf = policy_tree['leaf']
-
-    if leaf:
-        assert 'n_samples' in policy_tree
-        assert 'treatment' in policy_tree
+def _check_policy_tree(policy_tree, is_serialized=False):
+    if is_serialized:
+        if policy_tree.leaf:
+            assert isinstance(policy_tree, CausalPolicyTreeLeaf)
+            assert hasattr(policy_tree, 'treatment')
+            assert hasattr(policy_tree, 'n_samples')
+        else:
+            assert isinstance(policy_tree, CausalPolicyTreeInternal)
+            assert isinstance(policy_tree.feature, str)
+            assert hasattr(policy_tree, 'threshold')
+            _check_policy_tree(policy_tree.left,
+                               is_serialized=is_serialized)
+            _check_policy_tree(policy_tree.right,
+                               is_serialized=is_serialized)
     else:
-        assert 'feature' in policy_tree
-        assert isinstance(policy_tree['feature'], str)
-
-        assert 'threshold' in policy_tree
-        assert isinstance(policy_tree['threshold'], float)
-
-        assert 'left' in policy_tree
-        assert 'right' in policy_tree
-        _check_policy_tree(policy_tree['left'])
-        _check_policy_tree(policy_tree['right'])
+        assert isinstance(policy_tree, dict)
+        if policy_tree['leaf']:
+            assert 'treatment' in policy_tree
+            assert 'n_samples' in policy_tree
+        else:
+            assert isinstance(policy_tree['feature'], str)
+            assert isinstance(policy_tree['threshold'], float)
+            _check_policy_tree(policy_tree['left'],
+                               is_serialized=is_serialized)
+            _check_policy_tree(policy_tree['right'],
+                               is_serialized=is_serialized)

--- a/responsibleai/tests/test_model_analysis.py
+++ b/responsibleai/tests/test_model_analysis.py
@@ -90,7 +90,9 @@ class TestModelAnalysis(object):
         models = create_models_classification(X_train, y_train)
         X_train[LABELS] = y_train
         X_test[LABELS] = y_test
-        manager_args = None
+        manager_args = {
+            ManagerParams.TREATMENT_FEATURES: [0]
+        }
 
         for model in models:
             run_model_analysis(model, X_train, X_test, LABELS, [],

--- a/responsibleai/tests/test_serialization_utilities.py
+++ b/responsibleai/tests/test_serialization_utilities.py
@@ -1,0 +1,25 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import numpy as np
+
+from responsibleai.serialization_utilities import serialize_json_safe
+
+
+class TestSerializationUtilities:
+
+    def test_embedded_object(self):
+        class A:
+            def __init__(self):
+                self.a_data = 'a'
+
+        class B:
+            def __init__(self):
+                self.b_data = A()
+
+        result = serialize_json_safe({'B': B()})
+        assert result == {'B': {'b_data': {'a_data': 'a'}}}
+
+    def test_numpy(self):
+        result = serialize_json_safe(np.array([1, 2, 3]))
+        assert result == [1, 2, 3]

--- a/responsibleai/tests/test_serialization_utilities.py
+++ b/responsibleai/tests/test_serialization_utilities.py
@@ -23,3 +23,8 @@ class TestSerializationUtilities:
     def test_numpy(self):
         result = serialize_json_safe(np.array([1, 2, 3]))
         assert result == [1, 2, 3]
+
+    def test_unknown(self):
+        c = complex(1, 2)
+        result = serialize_json_safe([c, 42])
+        assert result == [c, 42]


### PR DESCRIPTION
Changes made:
- Make serialize_json_safe public so AzureML can use it
- Created new DTOs for causal policy for the dashboard
- Updated causal manager params to accept latest from EconML
- Local policies returns a pandas dataframe like local and global effects
- Added tests for both getand get_data