### PR TITLE
fix error analysis serialization when calling add after deserialize

### DIFF
--- a/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
@@ -29,7 +29,7 @@ class ModelAnalysisDashboardInput:
         self.dashboard_input = analysis.get_data()
         self._feature_length = len(self.dashboard_input.dataset.featureNames)
         self._row_length = len(self.dashboard_input.dataset.features)
-        self._error_analyzer = analysis.error_analysis.analyzer
+        self._error_analyzer = analysis.error_analysis._analyzer
 
     def on_predict(self, data):
         try:

--- a/responsibleai/responsibleai/_managers/error_analysis_manager.py
+++ b/responsibleai/responsibleai/_managers/error_analysis_manager.py
@@ -20,6 +20,7 @@ CONFIG = 'config'
 MAX_DEPTH = Keys.MAX_DEPTH
 NUM_LEAVES = Keys.NUM_LEAVES
 FILTER_FEATURES = Keys.FILTER_FEATURES
+IS_COMPUTED = 'is_computed'
 
 
 def config_json_converter(obj):
@@ -49,11 +50,16 @@ def as_error_config(json_dict):
     has_max_depth = MAX_DEPTH in json_dict
     has_num_leaves = NUM_LEAVES in json_dict
     has_filter_features = FILTER_FEATURES in json_dict
-    if has_max_depth and has_num_leaves and has_filter_features:
+    has_is_computed = IS_COMPUTED in json_dict
+    has_all_fields = (has_max_depth and has_num_leaves and
+                      has_filter_features and has_is_computed)
+    if has_all_fields:
         max_depth = json_dict[MAX_DEPTH]
         num_leaves = json_dict[NUM_LEAVES]
         filter_features = json_dict[FILTER_FEATURES]
-        return ErrorAnalysisConfig(max_depth, num_leaves, filter_features)
+        config = ErrorAnalysisConfig(max_depth, num_leaves, filter_features)
+        config.is_computed = json_dict[IS_COMPUTED]
+        return config
     else:
         return json_dict
 
@@ -111,7 +117,8 @@ class ErrorAnalysisConfig(BaseConfig):
         """
         return {'max_depth': self.max_depth,
                 'num_leaves': self.num_leaves,
-                'filter_features': self.filter_features}
+                'filter_features': self.filter_features,
+                'is_computed': self.is_computed}
 
     def to_json(self):
         """Serialize ErrorAnalysisConfig object to json.
@@ -157,18 +164,17 @@ class ErrorAnalysisManager(BaseManager):
         :param target_column: The name of the label column.
         :type target_column: str
         """
-        self._model = model
         self._y_train = train[target_column]
         self._train = train.drop(columns=[target_column])
         self._feature_names = list(self._train.columns)
         self._categorical_features = categorical_features
         self._ea_config_list = []
         self._ea_report_list = []
-        self.analyzer = ModelAnalyzer(self._model,
-                                      self._train,
-                                      self._y_train,
-                                      self._feature_names,
-                                      self._categorical_features)
+        self._analyzer = ModelAnalyzer(model,
+                                       self._train,
+                                       self._y_train,
+                                       self._feature_names,
+                                       self._categorical_features)
 
     def add(self, max_depth=3, num_leaves=31, filter_features=None):
         """Add an error analyzer to be computed later.
@@ -204,9 +210,10 @@ class ErrorAnalysisManager(BaseManager):
             config.is_computed = True
             max_depth = config.max_depth
             num_leaves = config.num_leaves
-            report = self.analyzer.create_error_report(config.filter_features,
-                                                       max_depth=max_depth,
-                                                       num_leaves=num_leaves)
+            filter_features = config.filter_features
+            report = self._analyzer.create_error_report(filter_features,
+                                                        max_depth=max_depth,
+                                                        num_leaves=num_leaves)
             self._ea_report_list.append(report)
 
     def get(self):
@@ -301,11 +308,18 @@ class ErrorAnalysisManager(BaseManager):
         with open(config_path, 'r') as file:
             ea_config_list = json.load(file, object_hook=as_error_config)
         inst.__dict__['_ea_config_list'] = ea_config_list
-        inst.__dict__['_categorical_features'] = None
+        categorical_features = model_analysis.categorical_features
+        inst.__dict__['_categorical_features'] = categorical_features
         target_column = model_analysis.target_column
         y_train = model_analysis.train[target_column]
         train = model_analysis.train.drop(columns=[target_column])
         inst.__dict__['_train'] = train
         inst.__dict__['_y_train'] = y_train
-        inst.__dict__['_feature_names'] = list(train.columns)
+        feature_names = list(train.columns)
+        inst.__dict__['_feature_names'] = feature_names
+        inst.__dict__['_analyzer'] = ModelAnalyzer(model_analysis.model,
+                                                   train,
+                                                   y_train,
+                                                   feature_names,
+                                                   categorical_features)
         return inst

--- a/responsibleai/tests/error_analysis_validator.py
+++ b/responsibleai/tests/error_analysis_validator.py
@@ -12,32 +12,32 @@ ERROR = 'error'
 ID = 'id'
 
 
-def setup_error_analysis(model_analysis, add_ea=True):
+def setup_error_analysis(model_analysis, add_ea=True, max_depth=3):
     if add_ea:
-        model_analysis.error_analysis.add()
+        model_analysis.error_analysis.add(max_depth=max_depth)
         with pytest.raises(DuplicateManagerConfigException):
-            model_analysis.error_analysis.add()
+            model_analysis.error_analysis.add(max_depth=max_depth)
     model_analysis.error_analysis.compute()
 
 
-def validate_error_analysis(model_analysis):
+def validate_error_analysis(model_analysis, expected_reports=1):
     reports = model_analysis.error_analysis.get()
     assert isinstance(reports, list)
-    assert len(reports) == 1
-    report = reports[0]
-    json_matrix = report.json_matrix
+    assert len(reports) == expected_reports
+    for report in reports:
+        json_matrix = report.json_matrix
 
-    ea_x_train = model_analysis.error_analysis._train
-    ea_y_train = model_analysis.error_analysis._y_train
+        ea_x_train = model_analysis.error_analysis._train
+        ea_y_train = model_analysis.error_analysis._y_train
 
-    expected_count = len(ea_x_train)
-    if json_matrix is not None:
-        predictions = model_analysis.model.predict(ea_x_train)
-        expected_false_count = sum(predictions != ea_y_train)
-        validate_matrix(json_matrix, expected_count, expected_false_count)
+        expected_count = len(ea_x_train)
+        if json_matrix is not None:
+            predictions = model_analysis.model.predict(ea_x_train)
+            expected_false_count = sum(predictions != ea_y_train)
+            validate_matrix(json_matrix, expected_count, expected_false_count)
 
-    json_tree = report.json_tree
-    validate_tree(json_tree, expected_count)
+        json_tree = report.json_tree
+        validate_tree(json_tree, expected_count)
 
 
 def validate_matrix(json_matrix, exp_total_count, exp_total_false_count):

--- a/responsibleai/tests/test_model_analysis.py
+++ b/responsibleai/tests/test_model_analysis.py
@@ -217,6 +217,9 @@ def run_model_analysis(model, train_data, test_data, target_column,
 
         if manager_type == ManagerNames.ERROR_ANALYSIS:
             validate_error_analysis(model_analysis)
+            # validate adding new reports after deserialization works
+            setup_error_analysis(model_analysis, max_depth=4)
+            validate_error_analysis(model_analysis, expected_reports=2)
         elif manager_type == ManagerNames.EXPLAINER:
             validate_explainer(model_analysis, train_data, test_data, classes)
 


### PR DESCRIPTION
I noticed some variables like categorical features were not set correctly, but the tests did not catch this because we didn't have a test that validated add() can be called on a deserialized manager.  Similar tests need to be added to other managers as I think they may suffer from similar issues.