### PR TITLE
Consume new PolicyOutput format from EconML

### DIFF
--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,5 +1,5 @@
 dice-ml>=0.6.1,<0.7
-econml>=0.12.0b2
+econml>=0.12.0b3
 erroranalysis>=0.1.8
 interpret-community>=0.18.1
 lightgbm>=2.0.11

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,5 +1,5 @@
 dice-ml>=0.6.1,<0.7
-econml>=0.12.0b3
+econml==0.12.0b3
 erroranalysis>=0.1.8
 interpret-community>=0.18.1
 lightgbm>=2.0.11

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -76,7 +76,7 @@ class CausalMetric:
 
 class CausalPolicyGains:
     recommended_policy_gains: float
-    treatment_gains: List[float]
+    treatment_gains: Dict[str, float]
     treatments: List[str]
 
 
@@ -96,6 +96,7 @@ class CausalPolicyTreeInternal:
 
 class CausalPolicy:
     treatment_feature: str
+    control_treatment: str
     local_policies: List[Dict[str, Any]]
     policy_gains: CausalPolicyGains
     policy_tree: Union[CausalPolicyTreeInternal, CausalPolicyTreeLeaf]

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -246,15 +246,10 @@ class CausalManager(BaseManager):
 
             config.policies = []
             for treatment_feature in config.treatment_features:
-                # Error handling required to mitigate
-                # individualized_policy bug in EconML version 0.12.0b2
-                try:
-                    local_policies = analysis.individualized_policy(
-                        X_test, treatment_feature,
-                        treatment_costs=config.treatment_cost,
-                        alpha=config.alpha)
-                except (IndexError, ValueError):
-                    local_policies = None
+                local_policies = analysis.individualized_policy(
+                    X_test, treatment_feature,
+                    treatment_costs=config.treatment_cost,
+                    alpha=config.alpha)
 
                 policy_tree, recommended_gains, treatment_gains = \
                     analysis._policy_tree_output(

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -252,7 +252,7 @@ class CausalManager(BaseManager):
                     treatment_costs=config.treatment_cost,
                     alpha=config.alpha)
 
-                tree_output = analysis._policy_tree_output(
+                tree = analysis._policy_tree_output(
                     X_test, treatment_feature,
                     treatment_costs=config.treatment_cost,
                     max_depth=config.max_tree_depth,
@@ -261,13 +261,13 @@ class CausalManager(BaseManager):
 
                 policy = {
                     self.TREATMENT_FEATURE: treatment_feature,
-                    self.CONTROL_TREATMENT: tree_output.control_name,
+                    self.CONTROL_TREATMENT: tree.control_name,
                     self.LOCAL_POLICIES: local_policies,
                     self.POLICY_GAINS: {
-                        self.RECOMMENDED_POLICY_GAINS: tree_output.policy_value,
-                        self.TREATMENT_GAINS: tree_output.always_treat,
+                        self.RECOMMENDED_POLICY_GAINS: tree.policy_value,
+                        self.TREATMENT_GAINS: tree.always_treat,
                     },
-                    self.POLICY_TREE: tree_output.tree_dictionary
+                    self.POLICY_TREE: tree.tree_dictionary
                 }
                 config.policies.append(policy)
 

--- a/responsibleai/tests/causal_manager_validator.py
+++ b/responsibleai/tests/causal_manager_validator.py
@@ -132,23 +132,30 @@ def _check_policy(policy, is_serialized=False):
     if is_serialized:
         assert isinstance(policy, CausalPolicy)
         treatment_feature = policy.treatment_feature
+        control_treatment = policy.control_treatment
         local_policies = policy.local_policies
         policy_gains = policy.policy_gains
         policy_tree = policy.policy_tree
     else:
         assert isinstance(policy, dict)
         treatment_feature = policy['treatment_feature']
+        control_treatment = policy['control_treatment']
         local_policies = policy['local_policies']
         policy_gains = policy['policy_gains']
         policy_tree = policy['policy_tree']
 
     _check_treatment_feature(treatment_feature)
+    _check_control_treatment(control_treatment)
     _check_local_policies(local_policies, is_serialized=is_serialized)
     _check_policy_gains(policy_gains, is_serialized=is_serialized)
     _check_policy_tree(policy_tree, is_serialized=is_serialized)
 
 
 def _check_treatment_feature(treatment_feature):
+    pass
+
+
+def _check_control_treatment(control_treatment):
     pass
 
 
@@ -175,8 +182,10 @@ def _check_policy_gains(policy_gains, is_serialized=False):
 
     assert isinstance(recommended_policy_gains, float)
 
-    assert isinstance(treatment_gains, list)
-    assert all(isinstance(v, float) for v in treatment_gains)
+    assert isinstance(treatment_gains, dict)
+    for treatment_name, treatment_value in treatment_gains.items():
+        assert isinstance(treatment_name, str)
+        assert isinstance(treatment_value, float)
 
 
 def _check_policy_tree(policy_tree, is_serialized=False):

--- a/responsibleai/tests/test_dependencies.py
+++ b/responsibleai/tests/test_dependencies.py
@@ -9,6 +9,7 @@ REQUIRED_DEPENDENCIES = [
     'econml',
     'dice-ml',
     'interpret-community',
+    'erroranalysis',
 ]
 
 DISALLOWED_DEPENDENCIES = [
@@ -16,12 +17,11 @@ DISALLOWED_DEPENDENCIES = [
     'keras',
     'pytorch',
     'matplotlib',
-    'graphviz'
+    'graphviz',
+    'jupyter'
 ]
 
-EXCEPTIONS = {
-    'econml': ['graphviz']
-}
+EXCEPTIONS = {}
 
 
 @pytest.fixture(scope='class')


### PR DESCRIPTION
Removes error handling required to work around a bug in the `0.12.0b2` version of EconML.