### PR TITLE
Remove deferred compute architecture for causal and counterfactual

### DIFF
--- a/notebooks/model-analysis.ipynb
+++ b/notebooks/model-analysis.ipynb
@@ -81,11 +81,10 @@
     "\n",
     "# Queue Responsible AI insights\n",
     "model_analysis.explainer.add()\n",
-    "model_analysis.counterfactual.add(10, desired_class='opposite')\n",
+    "model_analysis.counterfactual.compute(10, desired_class='opposite')\n",
     "model_analysis.error_analysis.add()\n",
-    "model_analysis.causal.add(treatment_features=['Hours per week'])\n",
+    "model_analysis.causal.compute(treatment_features=['Hours per week'])\n",
     "\n",
-    "# Compute insights\n",
     "model_analysis.compute()"
    ]
   },

--- a/raiwidgets/tests/test_model_analysis_dashboard.py
+++ b/raiwidgets/tests/test_model_analysis_dashboard.py
@@ -33,13 +33,14 @@ class TestModelAnalysisDashboard:
                                                  'Occupation', 'Relationship',
                                                  'Race',
                                                  'Sex', 'Country'])
-        ma.explainer.compute()
+        ma.explainer.add()
         ma.counterfactual.compute(10, desired_class='opposite')
-        ma.error_analysis.compute()
+        ma.error_analysis.add()
         ma.causal.compute(treatment_features=['Hours per week', 'Occupation'],
-                      heterogeneity_features=None,
-                      upper_bound_on_cat_expansion=42,
-                      skip_cat_limit_checks=True)
+                          heterogeneity_features=None,
+                          upper_bound_on_cat_expansion=42,
+                          skip_cat_limit_checks=True)
+        ma.compute()
 
         widget = ModelAnalysisDashboard(ma)
         assert isinstance(widget.input.dashboard_input.dataset,

--- a/raiwidgets/tests/test_model_analysis_dashboard.py
+++ b/raiwidgets/tests/test_model_analysis_dashboard.py
@@ -33,14 +33,13 @@ class TestModelAnalysisDashboard:
                                                  'Occupation', 'Relationship',
                                                  'Race',
                                                  'Sex', 'Country'])
-        ma.explainer.add()
-        ma.counterfactual.add(10, desired_class='opposite')
-        ma.error_analysis.add()
-        ma.causal.add(treatment_features=['Hours per week', 'Occupation'],
+        ma.explainer.compute()
+        ma.counterfactual.compute(10, desired_class='opposite')
+        ma.error_analysis.compute()
+        ma.causal.compute(treatment_features=['Hours per week', 'Occupation'],
                       heterogeneity_features=None,
                       upper_bound_on_cat_expansion=42,
                       skip_cat_limit_checks=True)
-        ma.compute()
 
         widget = ModelAnalysisDashboard(ma)
         assert isinstance(widget.input.dashboard_input.dataset,

--- a/responsibleai/responsibleai/_managers/base_manager.py
+++ b/responsibleai/responsibleai/_managers/base_manager.py
@@ -14,12 +14,8 @@ class BaseManager(ABC):
         super(BaseManager, self).__init__(*args, **kwargs)
 
     @abstractmethod
-    def add(self):
-        """Abstract method to add a computation to the manager."""
-
-    @abstractmethod
     def compute(self):
-        """Abstract method to compute the new work in the add method."""
+        """Abstract method to compute new model analysis insights."""
 
     @abstractmethod
     def get(self):

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -2,19 +2,17 @@
 # Licensed under the MIT License.
 
 """Defines the Causal Manager class."""
-import numpy as np
 import pandas as pd
 
 from econml.solutions.causal_analysis import CausalAnalysis
 
-from responsibleai._config.base_config import BaseConfig
 from responsibleai._interfaces import (
     CausalData, CausalPolicy, CausalPolicyGains,
     CausalPolicyTreeInternal, CausalPolicyTreeLeaf)
 from responsibleai._internal.constants import ManagerNames
 from responsibleai._managers.base_manager import BaseManager
 from responsibleai.exceptions import (
-    UserConfigValidationException, DuplicateManagerConfigException)
+    UserConfigValidationException)
 from responsibleai.modelanalysis.constants import ModelTask
 
 
@@ -23,6 +21,7 @@ class CausalConstants:
     AUTOML = 'automl'
     LINEAR = 'linear'
 
+    # Default parameter values
     DEFAULT_ALPHA = 0.05
     DEFAULT_MAX_CAT_EXPANSION = 50
     DEFAULT_TREATMENT_COST = 0
@@ -30,78 +29,7 @@ class CausalConstants:
     DEFAULT_MAX_TREE_DEPTH = 3
     DEFAULT_SKIP_CAT_LIMIT_CHECKS = False
 
-
-class CausalConfig(BaseConfig):
-    def __init__(
-        self,
-        treatment_features,
-        heterogeneity_features,
-        nuisance_model,
-        heterogeneity_model,
-        alpha,
-        max_cat_expansion,
-        treatment_cost,
-        min_tree_leaf_samples,
-        max_tree_depth,
-        skip_cat_limit_checks,
-    ):
-        super().__init__()
-        self.treatment_features = treatment_features
-        self.heterogeneity_features = heterogeneity_features
-        self.nuisance_model = nuisance_model
-        self.heterogeneity_model = heterogeneity_model
-        self.alpha = alpha
-        self.max_cat_expansion = max_cat_expansion
-        self.treatment_cost = treatment_cost
-        self.min_tree_leaf_samples = min_tree_leaf_samples
-        self.max_tree_depth = max_tree_depth
-        self.skip_cat_limit_checks = skip_cat_limit_checks
-
-        # Outputs
-        self.causal_analysis = None
-        self.global_effects = None
-        self.local_effects = None
-        self.policies = None
-
-    def __eq__(self, other):
-        return all([
-            np.array_equal(self.treatment_features,
-                           other.treatment_features),
-            np.array_equal(self.heterogeneity_features,
-                           other.heterogeneity_features),
-            self.nuisance_model == other.nuisance_model,
-            self.heterogeneity_model == other.heterogeneity_model,
-            self.alpha == other.alpha,
-            self.max_cat_expansion == other.max_cat_expansion,
-            self.treatment_cost == other.treatment_cost,
-            self.min_tree_leaf_samples == other.min_tree_leaf_samples,
-            self.max_tree_depth == other.max_tree_depth,
-            self.skip_cat_limit_checks == other.skip_cat_limit_checks,
-        ])
-
-    def __repr__(self):
-        return ("CausalConfig("
-                f"treatment_features={self.treatment_features}, "
-                f"heterogeneity_features={self.heterogeneity_features}, "
-                f"nuisance_model={self.nuisance_model}, "
-                f"heterogeneity_model={self.heterogeneity_model}, "
-                f"alpha={self.alpha}, "
-                f"max_cat_expansion={self.max_cat_expansion}, "
-                f"treatment_cost={self.treatment_cost}, "
-                f"min_tree_leaf_samples={self.min_tree_leaf_samples}, "
-                f"max_tree_depth={self.max_tree_depth}, "
-                f"skip_cat_limit_checks={self.skip_cat_limit_checks})")
-
-    def to_result(self):
-        return {
-            'causal_analysis': self.causal_analysis,
-            'global_effects': self.global_effects,
-            'local_effects': self.local_effects,
-            'policies': self.policies,
-        }
-
-
-class CausalManager(BaseManager):
+    # Causal result attributes
     TREATMENT_FEATURE = 'treatment_feature'
     LOCAL_POLICIES = 'local_policies'
     POLICY_TREE = 'policy_tree'
@@ -109,7 +37,6 @@ class CausalManager(BaseManager):
     CONTROL_TREATMENT = 'control_treatment'
     RECOMMENDED_POLICY_GAINS = 'recommended_policy_gains'
     TREATMENT_GAINS = 'treatment_gains'
-
     LEAF = 'leaf'
     N_SAMPLES = 'n_samples'
     TREATMENT = 'treatment'
@@ -118,6 +45,92 @@ class CausalManager(BaseManager):
     LEFT = 'left'
     RIGHT = 'right'
 
+
+class CausalResult:
+    def __init__(
+        self,
+        causal_analysis=None,
+        global_effects=None,
+        local_effects=None,
+        policies=None,
+    ):
+        self.causal_analysis = causal_analysis
+        self.global_effects = global_effects
+        self.local_effects = local_effects
+        self.policies = policies
+
+    def to_dict(self):
+        return {
+            'causal_analysis': self.causal_analysis,
+            'global_effects': self.global_effects,
+            'local_effects': self.local_effects,
+            'policies': self.policies,
+        }
+
+    def serialize(self):
+        causal_data = CausalData()
+        causal_data.global_effects = self.global_effects\
+            .reset_index().to_dict(orient='records')
+        local_dicts = self.local_effects.groupby('sample').apply(
+            lambda x: x.reset_index().to_dict(
+                orient='records')).values
+        causal_data.local_effects = [list(v) for v in local_dicts]
+        causal_data.policies = [self._get_policy_object(p) for p in
+                                self.policies]
+
+        return causal_data
+
+    def _get_policy_object(self, policy):
+        policy_object = CausalPolicy()
+        policy_object.treatment_feature = policy[
+            CausalConstants.TREATMENT_FEATURE]
+        policy_object.control_treatment = policy[
+            CausalConstants.CONTROL_TREATMENT]
+        policy_object.local_policies = self._get_local_policies_object(
+            policy[CausalConstants.LOCAL_POLICIES])
+        policy_object.policy_gains = self._get_policy_gains_object(
+            policy[CausalConstants.POLICY_GAINS])
+        policy_object.policy_tree = self._get_policy_tree_object(
+            policy[CausalConstants.POLICY_TREE])
+        return policy_object
+
+    def _get_local_policies_object(self, local_policies):
+        if local_policies is None:
+            return None
+
+        return local_policies.reset_index().\
+            to_dict(orient='records')
+
+    def _get_policy_tree_object(self, policy_tree):
+        if policy_tree[CausalConstants.LEAF]:
+            policy_tree_object = CausalPolicyTreeLeaf()
+            policy_tree_object.leaf = policy_tree[CausalConstants.LEAF]
+            policy_tree_object.n_samples = policy_tree[
+                CausalConstants.N_SAMPLES]
+            policy_tree_object.treatment = policy_tree[
+                CausalConstants.TREATMENT]
+        else:
+            policy_tree_object = CausalPolicyTreeInternal()
+            policy_tree_object.leaf = policy_tree[CausalConstants.LEAF]
+            policy_tree_object.feature = policy_tree[CausalConstants.FEATURE]
+            policy_tree_object.threshold = policy_tree[
+                CausalConstants.THRESHOLD]
+            policy_tree_object.left = self._get_policy_tree_object(
+                policy_tree[CausalConstants.LEFT])
+            policy_tree_object.right = self._get_policy_tree_object(
+                policy_tree[CausalConstants.RIGHT])
+        return policy_tree_object
+
+    def _get_policy_gains_object(self, policy_gains):
+        policy_gains_object = CausalPolicyGains()
+        policy_gains_object.recommended_policy_gains = \
+            policy_gains[CausalConstants.RECOMMENDED_POLICY_GAINS]
+        policy_gains_object.treatment_gains = \
+            policy_gains[CausalConstants.TREATMENT_GAINS]
+        return policy_gains_object
+
+
+class CausalManager(BaseManager):
     def __init__(self, train, test, target_column, task_type,
                  categorical_features):
         """Construct a CausalManager for generating causal analyses
@@ -141,9 +154,9 @@ class CausalManager(BaseManager):
         self._target_column = target_column
         self._task_type = task_type
         self._categorical_features = categorical_features
-        self._causal_config_list = []
+        self._results = []
 
-    def add(
+    def compute(
         self,
         treatment_features,
         heterogeneity_features=None,
@@ -156,7 +169,7 @@ class CausalManager(BaseManager):
         max_tree_depth=CausalConstants.DEFAULT_MAX_TREE_DEPTH,
         skip_cat_limit_checks=CausalConstants.DEFAULT_SKIP_CAT_LIMIT_CHECKS,
     ):
-        """Add a causal configuration to be computed later.
+        """Compute causal insights.
         :param treatment_features: Treatment feature names.
         :type treatment_features: list
         :param heterogeneity_features: Features that mediate the causal effect.
@@ -186,98 +199,78 @@ class CausalManager(BaseManager):
                                       will skip these checks.
         :type skip_cat_limit_checks: bool
         """
-        causal_config = CausalConfig(
+        if nuisance_model not in [CausalConstants.AUTOML,
+                                  CausalConstants.LINEAR]:
+            message = (f"nuisance_model should be one of "
+                       f"['{CausalConstants.AUTOML}', "
+                       f"'{CausalConstants.LINEAR}'], "
+                       f"got {nuisance_model}")
+            raise UserConfigValidationException(message)
+
+        is_classification = self._task_type == ModelTask.CLASSIFICATION
+        X = pd.concat([self._train, self._test], ignore_index=True)\
+            .drop([self._target_column], axis=1)
+        y = pd.concat([self._train, self._test], ignore_index=True)[
+            self._target_column].values.ravel()
+
+        analysis = CausalAnalysis(
             treatment_features,
-            heterogeneity_features=heterogeneity_features,
-            nuisance_model=nuisance_model,
-            heterogeneity_model=heterogeneity_model,
-            alpha=alpha,
-            max_cat_expansion=upper_bound_on_cat_expansion,
-            treatment_cost=treatment_cost,
-            min_tree_leaf_samples=min_tree_leaf_samples,
-            max_tree_depth=max_tree_depth,
-            skip_cat_limit_checks=skip_cat_limit_checks)
+            self._categorical_features,
+            heterogeneity_inds=heterogeneity_features,
+            classification=is_classification,
+            nuisance_models=nuisance_model,
+            upper_bound_on_cat_expansion=upper_bound_on_cat_expansion,
+            skip_cat_limit_checks=skip_cat_limit_checks,
+            n_jobs=-1)
+        analysis.fit(X, y)
 
-        if causal_config.is_duplicate(self._causal_config_list):
-            raise DuplicateManagerConfigException(
-                "Duplicate causal configuration detected.")
+        result = CausalResult()
 
-        self._causal_config_list.append(causal_config)
+        result.causal_analysis = analysis
 
-    def compute(self):
-        """Computes the causal insights by running the causal configuration."""
-        for config in self._causal_config_list:
-            if config.is_computed:
-                continue
+        X_test = self._test.drop([self._target_column], axis=1)
 
-            config.is_computed = True
-            if config.nuisance_model not in [CausalConstants.AUTOML,
-                                             CausalConstants.LINEAR]:
-                message = (f"nuisance_model should be one of "
-                           f"['{CausalConstants.AUTOML}', "
-                           f"'{CausalConstants.LINEAR}'], "
-                           f"got {config.nuisance_model}")
-                raise UserConfigValidationException(message)
+        result.global_effects = analysis.global_causal_effect(
+            alpha=alpha)
+        result.local_effects = analysis.local_causal_effect(
+            X_test, alpha=alpha)
 
-            is_classification = self._task_type == ModelTask.CLASSIFICATION
-            X = pd.concat([self._train, self._test], ignore_index=True)\
-                .drop([self._target_column], axis=1)
-            y = pd.concat([self._train, self._test], ignore_index=True)[
-                self._target_column].values.ravel()
-
-            analysis = CausalAnalysis(
-                config.treatment_features,
-                self._categorical_features,
-                heterogeneity_inds=config.heterogeneity_features,
-                classification=is_classification,
-                nuisance_models=config.nuisance_model,
-                upper_bound_on_cat_expansion=config.max_cat_expansion,
-                skip_cat_limit_checks=config.skip_cat_limit_checks,
-                n_jobs=-1)
-            analysis.fit(X, y)
-
-            config.causal_analysis = analysis
-
-            X_test = self._test.drop([self._target_column], axis=1)
-
-            config.global_effects = analysis.global_causal_effect(
-                alpha=config.alpha)
-            config.local_effects = analysis.local_causal_effect(
-                X_test, alpha=config.alpha)
-
-            config.policies = []
-            for treatment_feature in config.treatment_features:
+        result.policies = []
+        for treatment_feature in treatment_features:
+            # Error handling required to mitigate
+            # individualized_policy bug in EconML version 0.12.0b2
+            try:
                 local_policies = analysis.individualized_policy(
                     X_test, treatment_feature,
-                    treatment_costs=config.treatment_cost,
-                    alpha=config.alpha)
+                    treatment_costs=treatment_cost,
+                    alpha=alpha)
+            except (IndexError, ValueError):
+                local_policies = None
 
-                tree = analysis._policy_tree_output(
-                    X_test, treatment_feature,
-                    treatment_costs=config.treatment_cost,
-                    max_depth=config.max_tree_depth,
-                    min_samples_leaf=config.min_tree_leaf_samples,
-                    alpha=config.alpha)
+            tree = analysis._policy_tree_output(
+                X_test, treatment_feature,
+                treatment_costs=treatment_cost,
+                max_depth=max_tree_depth,
+                min_samples_leaf=min_tree_leaf_samples,
+                alpha=alpha)
 
-                policy = {
-                    self.TREATMENT_FEATURE: treatment_feature,
-                    self.CONTROL_TREATMENT: tree.control_name,
-                    self.LOCAL_POLICIES: local_policies,
-                    self.POLICY_GAINS: {
-                        self.RECOMMENDED_POLICY_GAINS: tree.policy_value,
-                        self.TREATMENT_GAINS: tree.always_treat,
-                    },
-                    self.POLICY_TREE: tree.tree_dictionary
-                }
-                config.policies.append(policy)
+            policy = {
+                CausalConstants.TREATMENT_FEATURE: treatment_feature,
+                CausalConstants.CONTROL_TREATMENT: tree.control_name,
+                CausalConstants.LOCAL_POLICIES: local_policies,
+                CausalConstants.POLICY_GAINS: {
+                    CausalConstants.RECOMMENDED_POLICY_GAINS:
+                        tree.policy_value,
+                    CausalConstants.TREATMENT_GAINS: tree.always_treat,
+                },
+                CausalConstants.POLICY_TREE: tree.tree_dictionary
+            }
+            result.policies.append(policy)
+        self._results.append(result)
 
     def get(self):
         """Get the computed causal insights."""
-        results = []
-        for config in self._causal_config_list:
-            if config.is_computed:
-                results.append(config.to_result())
-        return results
+        return [result.to_dict() for result in self._results]
 
     def list(self):
         pass
@@ -288,65 +281,7 @@ class CausalManager(BaseManager):
         :return: List of CausalData objects.
         :rtype: List[CausalData]
         """
-        return [self._get_causal_object(insights) for insights in self.get()]
-
-    def _get_causal_object(self, causal_insights):
-        causal_data = CausalData()
-        causal_data.global_effects = causal_insights['global_effects']\
-            .reset_index().to_dict(orient='records')
-        causal_data.local_effects = [list(v) for v in causal_insights[
-            'local_effects'].groupby('sample').apply(
-                lambda x: x.reset_index().to_dict(
-                    orient='records')).values]
-
-        causal_data.policies = [self._get_policy_object(p) for p in
-                                causal_insights['policies']]
-
-        return causal_data
-
-    def _get_policy_object(self, policy):
-        policy_object = CausalPolicy()
-        policy_object.treatment_feature = policy[self.TREATMENT_FEATURE]
-        policy_object.control_treatment = policy[self.CONTROL_TREATMENT]
-        policy_object.local_policies = self._get_local_policies_object(
-            policy[self.LOCAL_POLICIES])
-        policy_object.policy_gains = self._get_policy_gains_object(
-            policy[self.POLICY_GAINS])
-        policy_object.policy_tree = self._get_policy_tree_object(
-            policy[self.POLICY_TREE])
-        return policy_object
-
-    def _get_local_policies_object(self, local_policies):
-        if local_policies is None:
-            return None
-
-        return local_policies.reset_index().\
-            to_dict(orient='records')
-
-    def _get_policy_tree_object(self, policy_tree):
-        if policy_tree[self.LEAF]:
-            policy_tree_object = CausalPolicyTreeLeaf()
-            policy_tree_object.leaf = policy_tree[self.LEAF]
-            policy_tree_object.n_samples = policy_tree[self.N_SAMPLES]
-            policy_tree_object.treatment = policy_tree[self.TREATMENT]
-        else:
-            policy_tree_object = CausalPolicyTreeInternal()
-            policy_tree_object.leaf = policy_tree[self.LEAF]
-            policy_tree_object.feature = policy_tree[self.FEATURE]
-            policy_tree_object.threshold = policy_tree[self.THRESHOLD]
-            policy_tree_object.left = self._get_policy_tree_object(
-                policy_tree[self.LEFT])
-            policy_tree_object.right = self._get_policy_tree_object(
-                policy_tree[self.RIGHT])
-        return policy_tree_object
-
-    def _get_policy_gains_object(self, policy_gains):
-        policy_gains_object = CausalPolicyGains()
-        policy_gains_object.recommended_policy_gains = \
-            policy_gains[self.RECOMMENDED_POLICY_GAINS]
-        policy_gains_object.treatment_gains = \
-            policy_gains[self.TREATMENT_GAINS]
-        return policy_gains_object
+        return [result.serialize() for result in self._results]
 
     @property
     def name(self):

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -131,8 +131,14 @@ class CausalResult:
 
 
 class CausalManager(BaseManager):
-    def __init__(self, train, test, target_column, task_type,
-                 categorical_features):
+    def __init__(
+        self,
+        train,
+        test,
+        target_column,
+        task_type,
+        categorical_features
+    ):
         """Construct a CausalManager for generating causal analyses
            from a dataset.
 
@@ -154,6 +160,7 @@ class CausalManager(BaseManager):
         self._target_column = target_column
         self._task_type = task_type
         self._categorical_features = categorical_features
+
         self._results = []
 
     def compute(
@@ -161,7 +168,7 @@ class CausalManager(BaseManager):
         treatment_features,
         heterogeneity_features=None,
         nuisance_model=CausalConstants.LINEAR,
-        heterogeneity_model=None,
+        heterogeneity_model=CausalConstants.LINEAR,
         alpha=CausalConstants.DEFAULT_ALPHA,
         upper_bound_on_cat_expansion=CausalConstants.DEFAULT_MAX_CAT_EXPANSION,
         treatment_cost=CausalConstants.DEFAULT_TREATMENT_COST,
@@ -219,6 +226,7 @@ class CausalManager(BaseManager):
             heterogeneity_inds=heterogeneity_features,
             classification=is_classification,
             nuisance_models=nuisance_model,
+            heterogeneity_model=heterogeneity_model,
             upper_bound_on_cat_expansion=upper_bound_on_cat_expansion,
             skip_cat_limit_checks=skip_cat_limit_checks,
             n_jobs=-1)

--- a/responsibleai/responsibleai/modelanalysis/model_analysis.py
+++ b/responsibleai/responsibleai/modelanalysis/model_analysis.py
@@ -116,6 +116,10 @@ class ModelAnalysis(object):
                           self._counterfactual_manager,
                           self._error_analysis_manager,
                           self._explainer_manager]
+        self._add_managers = [
+            self._error_analysis_manager,
+            self._explainer_manager,
+        ]
 
     @property
     def causal(self) -> CausalManager:
@@ -151,7 +155,7 @@ class ModelAnalysis(object):
 
     def compute(self):
         """Calls compute on each of the managers."""
-        for manager in self._managers:
+        for manager in self._add_managers:
             manager.compute()
 
     def list(self):

--- a/responsibleai/tests/counterfactual_manager_validator.py
+++ b/responsibleai/tests/counterfactual_manager_validator.py
@@ -26,33 +26,24 @@ def validate_counterfactual(cf_analyzer,
                             feature_importance=False):
 
     # Add the first configuration
-    cf_analyzer.counterfactual.add(total_CFs=10,
-                                   method='random',
-                                   desired_class=desired_class,
-                                   desired_range=desired_range,
-                                   feature_importance=feature_importance)
-    cf_analyzer.counterfactual.compute()
+    cf_analyzer.counterfactual.compute(
+        total_CFs=10, method='random',
+        desired_class=desired_class,
+        desired_range=desired_range,
+        feature_importance=feature_importance)
+
     assert cf_analyzer.counterfactual.get() is not None
     assert isinstance(cf_analyzer.counterfactual.get(), list)
     assert len(cf_analyzer.counterfactual.get()) == 1
     verify_counterfactual_object(cf_analyzer.counterfactual.get()[0],
                                  feature_importance=feature_importance)
 
-    # Add a duplicate configuration
-    with pytest.raises(DuplicateManagerConfigException):
-        cf_analyzer.counterfactual.add(total_CFs=10,
-                                       method='random',
-                                       desired_class=desired_class,
-                                       desired_range=desired_range,
-                                       feature_importance=feature_importance)
-
     # Add the second configuration
-    cf_analyzer.counterfactual.add(total_CFs=20,
-                                   method='random',
-                                   desired_class=desired_class,
-                                   desired_range=desired_range,
-                                   feature_importance=feature_importance)
-    cf_analyzer.counterfactual.compute()
+    cf_analyzer.counterfactual.compute(
+        total_CFs=20, method='random',
+        desired_class=desired_class, desired_range=desired_range,
+        feature_importance=feature_importance)
+
     assert cf_analyzer.counterfactual.get() is not None
     assert isinstance(cf_analyzer.counterfactual.get(), list)
     assert len(cf_analyzer.counterfactual.get()) == 2
@@ -63,28 +54,26 @@ def validate_counterfactual(cf_analyzer,
 
     # Add a bad configuration
     with pytest.raises(DiceException):
-        cf_analyzer.counterfactual.add(total_CFs=-20,
-                                       method='random',
-                                       desired_class=desired_class,
-                                       desired_range=desired_range,
-                                       feature_importance=feature_importance)
-        cf_analyzer.counterfactual.compute()
+        cf_analyzer.counterfactual.compute(
+            total_CFs=-20, method='random',
+            desired_class=desired_class, desired_range=desired_range,
+            feature_importance=feature_importance)
+
     assert cf_analyzer.counterfactual.get() is not None
     assert isinstance(cf_analyzer.counterfactual.get(), list)
     assert len(cf_analyzer.counterfactual.get()) == 2
-    assert len(cf_analyzer.counterfactual.get(failed_to_compute=True)) == 1
 
     task_type = cf_analyzer.task_type
     if task_type == ModelTask.REGRESSION:
         with pytest.raises(UserConfigValidationException):
-            cf_analyzer.counterfactual.add(
+            cf_analyzer.counterfactual.compute(
                 total_CFs=10,
                 method='random',
                 desired_range=None,
                 feature_importance=feature_importance)
     else:
         with pytest.raises(UserConfigValidationException):
-            cf_analyzer.counterfactual.add(
+            cf_analyzer.counterfactual.compute(
                 total_CFs=10,
                 method='random',
                 desired_class=None,


### PR DESCRIPTION
Changes `add()/compute()` design of managers to be `compute()` only. The computed insights will still be saved to the managers for `get()` and `list()` to work as previously designed.