### PR TITLE
Show add button only for components that can render

### DIFF
--- a/apps/dashboard/src/app/applications.ts
+++ b/apps/dashboard/src/app/applications.ts
@@ -4,7 +4,8 @@
 import {
   IExplanationDashboardData,
   ISerializedExplanationData,
-  IFairnessData
+  IFairnessData,
+  IDataset
 } from "@responsible-ai/core-ui";
 import { IModelAssessmentData } from "@responsible-ai/model-assessment";
 
@@ -150,6 +151,32 @@ export const applications: IApplications = <const>{
         dataset: adultCensusWithFairnessDataset,
         errorAnalysisConfig: [adultCensusCausalErrorAnalysisConfig],
         modelExplanationData: [adultCensusWithFairnessModelExplanationData]
+      } as IModelAssessmentDataSet,
+      adultCensusIncomeNoCausalData: {
+        classDimension: 2,
+        counterfactualData: [adultCounterfactualData],
+        dataset: adultCensusWithFairnessDataset,
+        errorAnalysisConfig: [adultCensusCausalErrorAnalysisConfig],
+        modelExplanationData: [adultCensusWithFairnessModelExplanationData]
+      } as IModelAssessmentDataSet,
+      adultCensusIncomeNoCounterfactualData: {
+        causalAnalysisData: [adultCensusCausalAnalysisData],
+        classDimension: 2,
+        dataset: adultCensusWithFairnessDataset,
+        errorAnalysisConfig: [adultCensusCausalErrorAnalysisConfig],
+        modelExplanationData: [adultCensusWithFairnessModelExplanationData]
+      } as IModelAssessmentDataSet,
+      adultCensusIncomeNoModelData: {
+        classDimension: 2,
+        dataset: {
+          categorical_map: adultCensusWithFairnessDataset.categorical_map,
+          class_names: adultCensusWithFairnessDataset.class_names,
+          feature_names: adultCensusWithFairnessDataset.feature_names,
+          features: adultCensusWithFairnessDataset.features,
+          target_column: adultCensusWithFairnessDataset.target_column,
+          task_type: adultCensusWithFairnessDataset.task_type,
+          true_y: adultCensusWithFairnessDataset.true_y
+        } as IDataset
       } as IModelAssessmentDataSet
     },
     versions: { "Version-1": 1 }

--- a/apps/dashboard/src/model-assessment/App.tsx
+++ b/apps/dashboard/src/model-assessment/App.tsx
@@ -12,7 +12,6 @@ import { ITheme } from "office-ui-fabric-react";
 import React from "react";
 
 import {
-  generateJsonTreeAdultCensusIncome,
   generateJsonMatrix,
   generateJsonTreeBreastCancer,
   createJsonImportancesGenerator,
@@ -47,8 +46,8 @@ export class App extends React.Component<IAppProps> {
     const modelAssessmentDashboardProps: IModelAssessmentDashboardProps = {
       ...this.props,
       locale: this.props.language,
-      localUrl: "",
-      requestDebugML: generateJsonTreeAdultCensusIncome,
+      localUrl: "https://www.bing.com/",
+      requestDebugML: generateJsonTreeBreastCancer,
       requestImportances: createJsonImportancesGenerator(
         this.props.dataset.feature_names,
         DatasetName.BreastCancer
@@ -59,17 +58,6 @@ export class App extends React.Component<IAppProps> {
         : createPredictionsRequestGenerator(this.props.classDimension),
       stringParams: { contextualHelp: this.messages }
     };
-
-    if ("categoricalMap" in this.props.dataset) {
-      return <ModelAssessmentDashboard {...modelAssessmentDashboardProps} />;
-    }
-
-    modelAssessmentDashboardProps.localUrl = "https://www.bing.com/";
-    modelAssessmentDashboardProps.requestDebugML = generateJsonTreeBreastCancer;
-    modelAssessmentDashboardProps.requestImportances = createJsonImportancesGenerator(
-      this.props.dataset.feature_names,
-      DatasetName.BreastCancer
-    );
 
     return <ModelAssessmentDashboard {...modelAssessmentDashboardProps} />;
   }

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/AddTabButton.tsx
@@ -17,6 +17,7 @@ import { addTabButtonStyles } from "./AddTabButton.styles";
 import { GlobalTabKeys } from "./ModelAssessmentEnums";
 export interface IAddTabButtonProps {
   tabIndex: number;
+  availableTabs: IDropdownOption[];
   onAdd(index: number, tab: GlobalTabKeys): void;
 }
 interface IAddTabButtonState {
@@ -29,28 +30,6 @@ export class AddTabButton extends React.Component<
   IAddTabButtonState
 > {
   private buttonId = getRandomId();
-  private dropdownOptions: IDropdownOption[] = [
-    {
-      key: GlobalTabKeys.DataExplorerTab,
-      text: localization.ModelAssessment.ComponentNames.DataExplorer
-    },
-    {
-      key: GlobalTabKeys.FeatureImportancesTab,
-      text: localization.ModelAssessment.ComponentNames.FeatureImportances
-    },
-    {
-      key: GlobalTabKeys.ModelStatisticsTab,
-      text: localization.ModelAssessment.ComponentNames.ModelStatistics
-    },
-    {
-      key: GlobalTabKeys.CounterfactualsTab,
-      text: localization.ModelAssessment.ComponentNames.Counterfactuals
-    },
-    {
-      key: GlobalTabKeys.CausalAnalysisTab,
-      text: localization.ModelAssessment.ComponentNames.CausalAnalysis
-    }
-  ];
   public constructor(props: IAddTabButtonProps) {
     super(props);
     this.state = {
@@ -81,7 +60,7 @@ export class AddTabButton extends React.Component<
               <Stack tokens={{ childrenGap: "l1" }}>
                 {localization.ModelAssessment.AddingTab.CalloutContent}
                 <Dropdown
-                  options={this.dropdownOptions}
+                  options={this.props.availableTabs}
                   onChange={this.onChange}
                 />
                 <PrimaryButton

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/AvailableTabs.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/AvailableTabs.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { JointDataset } from "@responsible-ai/core-ui";
+import { localization } from "@responsible-ai/localization";
+import { IModelAssessmentDashboardProps } from "@responsible-ai/model-assessment";
+import { IDropdownOption } from "office-ui-fabric-react";
+
+import { GlobalTabKeys } from "./ModelAssessmentEnums";
+
+export function getAvailableTabs(
+  props: IModelAssessmentDashboardProps,
+  jointDataset: JointDataset,
+  excludeErrorAnalysis: boolean
+): IDropdownOption[] {
+  const availableTabs: IDropdownOption[] = [];
+  if (
+    !excludeErrorAnalysis &&
+    props.requestDebugML &&
+    props.requestMatrix &&
+    props.requestImportances
+  ) {
+    availableTabs.push({
+      key: GlobalTabKeys.ErrorAnalysisTab,
+      text: localization.ModelAssessment.ComponentNames.ErrorAnalysis
+    });
+  }
+
+  if (jointDataset.hasPredictedY && jointDataset.hasTrueY) {
+    availableTabs.push({
+      key: GlobalTabKeys.ModelStatisticsTab,
+      text: localization.ModelAssessment.ComponentNames.ModelStatistics
+    });
+  }
+
+  if (jointDataset.hasDataset) {
+    availableTabs.push({
+      key: GlobalTabKeys.DataExplorerTab,
+      text: localization.ModelAssessment.ComponentNames.DataExplorer
+    });
+  }
+
+  if (
+    props.requestPredictions &&
+    props.requestImportances &&
+    props.modelExplanationData &&
+    props.modelExplanationData.length > 0
+  ) {
+    availableTabs.push({
+      key: GlobalTabKeys.FeatureImportancesTab,
+      text: localization.ModelAssessment.ComponentNames.FeatureImportances
+    });
+  }
+
+  if (props.causalAnalysisData && props.causalAnalysisData.length > 0) {
+    availableTabs.push({
+      key: GlobalTabKeys.CausalAnalysisTab,
+      text: localization.ModelAssessment.ComponentNames.CausalAnalysis
+    });
+  }
+
+  if (props.counterfactualData && props.counterfactualData.length > 0) {
+    availableTabs.push({
+      key: GlobalTabKeys.CounterfactualsTab,
+      text: localization.ModelAssessment.ComponentNames.Counterfactuals
+    });
+  }
+  return availableTabs;
+}

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Context/buildModelAssessmentContext.ts
@@ -25,8 +25,12 @@ import {
 import { localization } from "@responsible-ai/localization";
 import { ModelMetadata } from "@responsible-ai/mlchartlib";
 
+import { getAvailableTabs } from "../AvailableTabs";
 import { IModelAssessmentDashboardProps } from "../ModelAssessmentDashboardProps";
-import { IModelAssessmentDashboardState } from "../ModelAssessmentDashboardState";
+import {
+  IModelAssessmentDashboardState,
+  IModelAssessmentDashboardTab
+} from "../ModelAssessmentDashboardState";
 import { PredictionTabKeys, GlobalTabKeys } from "../ModelAssessmentEnums";
 
 export function buildInitialModelAssessmentContext(
@@ -82,33 +86,21 @@ export function buildInitialModelAssessmentContext(
     );
     weightVectorOptions.push(index);
   });
+
+  // only include tabs for which we have the required data
+  const activeGlobalTabs: IModelAssessmentDashboardTab[] = getAvailableTabs(
+    props,
+    jointDataset,
+    false
+  ).map((item) => {
+    return {
+      dataCount: jointDataset.datasetRowCount,
+      key: item.key as GlobalTabKeys
+    };
+  });
+
   return {
-    activeGlobalTabs: [
-      {
-        dataCount: jointDataset.datasetRowCount,
-        key: GlobalTabKeys.ErrorAnalysisTab
-      },
-      {
-        dataCount: jointDataset.datasetRowCount,
-        key: GlobalTabKeys.ModelStatisticsTab
-      },
-      {
-        dataCount: jointDataset.datasetRowCount,
-        key: GlobalTabKeys.DataExplorerTab
-      },
-      {
-        dataCount: jointDataset.datasetRowCount,
-        key: GlobalTabKeys.FeatureImportancesTab
-      },
-      {
-        dataCount: jointDataset.datasetRowCount,
-        key: GlobalTabKeys.CausalAnalysisTab
-      },
-      {
-        dataCount: jointDataset.datasetRowCount,
-        key: GlobalTabKeys.CounterfactualsTab
-      }
-    ],
+    activeGlobalTabs,
     baseCohort: cohorts[0],
     cohorts,
     createCohortVisible: false,

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -30,10 +30,17 @@ import {
 import { ModelPerformanceTab } from "@responsible-ai/interpret";
 import { localization } from "@responsible-ai/localization";
 import _ from "lodash";
-import { DefaultEffects, PivotItem, Stack, Text } from "office-ui-fabric-react";
+import {
+  DefaultEffects,
+  IDropdownOption,
+  PivotItem,
+  Stack,
+  Text
+} from "office-ui-fabric-react";
 import * as React from "react";
 
 import { AddTabButton } from "./AddTabButton";
+import { getAvailableTabs } from "./AvailableTabs";
 import { buildInitialModelAssessmentContext } from "./Context/buildModelAssessmentContext";
 import { FeatureImportancesTab } from "./Controls/FeatureImportances";
 import { MainMenu } from "./Controls/MainMenu";
@@ -46,12 +53,20 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
   IModelAssessmentDashboardProps,
   IModelAssessmentDashboardState
 > {
+  private addTabDropdownOptions: IDropdownOption[];
+
   public constructor(props: IModelAssessmentDashboardProps) {
     super(props);
     if (this.props.locale) {
       localization.setLanguage(this.props.locale);
     }
     this.state = buildInitialModelAssessmentContext(_.cloneDeep(props));
+
+    this.addTabDropdownOptions = getAvailableTabs(
+      this.props,
+      this.state.jointDataset,
+      true
+    );
 
     if (this.props.requestImportances) {
       this.props
@@ -132,7 +147,11 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
               <Stack.Item
                 className={modelAssessmentDashboardStyles.buttonSection}
               >
-                <AddTabButton tabIndex={0} onAdd={this.addTab} />
+                <AddTabButton
+                  tabIndex={0}
+                  onAdd={this.addTab}
+                  availableTabs={this.addTabDropdownOptions}
+                />
               </Stack.Item>
             )}
             {this.state.activeGlobalTabs.map((t, i) => (
@@ -145,11 +164,7 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
                   {t.key === GlobalTabKeys.ErrorAnalysisTab &&
                     this.props.errorAnalysisConfig?.[0] && (
                       <ErrorAnalysisViewTab
-                        messages={
-                          this.props.stringParams
-                            ? this.props.stringParams.contextualHelp
-                            : undefined
-                        }
+                        messages={this.props.stringParams?.contextualHelp}
                         getTreeNodes={this.props.requestDebugML}
                         getMatrix={this.props.requestMatrix}
                         updateSelectedCohort={this.updateSelectedCohort}
@@ -273,7 +288,11 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
                 <Stack.Item
                   className={modelAssessmentDashboardStyles.buttonSection}
                 >
-                  <AddTabButton tabIndex={0} onAdd={this.addTab} />
+                  <AddTabButton
+                    tabIndex={0}
+                    onAdd={this.addTab}
+                    availableTabs={this.addTabDropdownOptions}
+                  />
                 </Stack.Item>
               </>
             ))}


### PR DESCRIPTION
closes #646 
closes #647 

Also added datasets (or rather variations of the existing one) where some data is missing to test the MAD without some components and to ensure the right options show up in the dropdown.

Signed-off-by: Roman Lutz <rolutz@microsoft.com>