### PR TITLE
Causal analysis to keep all levels in DataFrame outputs

### DIFF
--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,5 +1,5 @@
 dice-ml>=0.6.1,<0.7
-econml==0.12.0b3
+econml==0.12.0b4
 erroranalysis>=0.1.8
 interpret-community>=0.18.1
 lightgbm>=2.0.11

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -245,9 +245,9 @@ class CausalManager(BaseManager):
             X_test = self._test.drop([self._target_column], axis=1)
 
             config.global_effects = analysis.global_causal_effect(
-                alpha=config.alpha)
+                alpha=config.alpha, keep_all_levels=True)
             config.local_effects = analysis.local_causal_effect(
-                X_test, alpha=config.alpha)
+                X_test, alpha=config.alpha, keep_all_levels=True)
 
             config.policies = []
             for treatment_feature in config.treatment_features:


### PR DESCRIPTION
Upgrades to `econml` `0.12.0b4` which supports keeping all DataFrame levels