### PR TITLE
expand the number of decimals shown in filter tooltip in tree view and matrix filter if values below 0.1

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FilterTooltip/FilterTooltip.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FilterTooltip/FilterTooltip.styles.ts
@@ -18,7 +18,7 @@ export interface IFilterTooltipStyles {
   smallHeader: IStyle;
   valueRed: IStyle;
   valueBlack: IStyle;
-  errorRateCell: IStyle;
+  metricValueCell: IStyle;
   errorCoverageCell: IStyle;
   numCorrect: IStyle;
   numIncorrect: IStyle;
@@ -43,9 +43,6 @@ export const filterTooltipStyles: () => IProcessedStyleSet<
     errorCoverageCell: {
       transform: "translate(20px, 45px)"
     },
-    errorRateCell: {
-      transform: "translate(20px, 75px)"
-    },
     hideFilterTooltip: {
       visibility: "hidden"
     },
@@ -55,6 +52,9 @@ export const filterTooltipStyles: () => IProcessedStyleSet<
     metricBarRed: mergeStyles(metricBar, {
       fill: theme.palette.red
     }),
+    metricValueCell: {
+      transform: "translate(20px, 75px)"
+    },
     numCorrect: {
       fontSize: "8px",
       fontWeight: "500",

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FilterTooltip/FilterTooltip.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/FilterTooltip/FilterTooltip.tsx
@@ -43,7 +43,9 @@ export class FilterTooltip extends React.Component<IFilterTooltipProps> {
               </text>
               <text className={classNames.numIncorrect}>
                 {localization.ErrorAnalysis.FilterTooltip.errorSum}
-                {this.props.filterProps.numIncorrect.toFixed(2)}
+                {this.props.filterProps.numIncorrect > 0.1
+                  ? this.props.filterProps.numIncorrect.toFixed(2)
+                  : this.props.filterProps.numIncorrect.toFixed(4)}
               </text>
             </g>
           )}
@@ -70,7 +72,7 @@ export class FilterTooltip extends React.Component<IFilterTooltipProps> {
               </text>
             </g>
           </g>
-          <g className={classNames.errorRateCell}>
+          <g className={classNames.metricValueCell}>
             <rect className={classNames.metricBarRed} />
             <g>
               <text className={classNames.smallHeader}>
@@ -80,7 +82,9 @@ export class FilterTooltip extends React.Component<IFilterTooltipProps> {
                 )}
               </text>
               <text className={classNames.valueBlack}>
-                {this.props.filterProps.metricValue.toFixed(2)}
+                {this.props.filterProps.metricValue > 0.1
+                  ? this.props.filterProps.metricValue.toFixed(2)
+                  : this.props.filterProps.metricValue.toFixed(4)}
                 {isErrorRate ? "%" : ""}
               </text>
             </g>


### PR DESCRIPTION
Expand the number of decimal places in the tree view and matrix filter tooltips by two decimal places if they are below 0.1:

![image](https://user-images.githubusercontent.com/24683184/125668203-8c02832d-b262-4876-af4e-d572cb3733fe.png)

![image](https://user-images.githubusercontent.com/24683184/125668238-3999add9-9e63-4e31-b6ca-1286f71135a8.png)
