### PR TITLE
use test data instead of train data for error analysis in model analysis dashboard

### DIFF
--- a/responsibleai/responsibleai/_managers/error_analysis_manager.py
+++ b/responsibleai/responsibleai/_managers/error_analysis_manager.py
@@ -146,33 +146,34 @@ class ErrorAnalysisManager(BaseManager):
         A model that implements sklearn.predict or sklearn.predict_proba
         or function that accepts a 2d ndarray.
     :type model: object
-    :param train: The training dataset including the label column.
-    :type train: pandas.DataFrame
+    :param dataset: The dataset including the label column.
+    :type dataset: pandas.DataFrame
     :param target_column: The name of the label column.
     :type target_column: str
     """
 
-    def __init__(self, model, train, target_column, categorical_features=None):
+    def __init__(self, model, dataset, target_column,
+                 categorical_features=None):
         """Defines the ErrorAnalysisManager for discovering errors in a model.
 
         :param model: The model to analyze errors on.
             A model that implements sklearn.predict or sklearn.predict_proba
             or function that accepts a 2d ndarray.
         :type model: object
-        :param train: The training dataset including the label column.
-        :type train: pandas.DataFrame
+        :param dataset: The dataset including the label column.
+        :type dataset: pandas.DataFrame
         :param target_column: The name of the label column.
         :type target_column: str
         """
-        self._y_train = train[target_column]
-        self._train = train.drop(columns=[target_column])
-        self._feature_names = list(self._train.columns)
+        self._true_y = dataset[target_column]
+        self._dataset = dataset.drop(columns=[target_column])
+        self._feature_names = list(self._dataset.columns)
         self._categorical_features = categorical_features
         self._ea_config_list = []
         self._ea_report_list = []
         self._analyzer = ModelAnalyzer(model,
-                                       self._train,
-                                       self._y_train,
+                                       self._dataset,
+                                       self._true_y,
                                        self._feature_names,
                                        self._categorical_features)
 
@@ -311,15 +312,15 @@ class ErrorAnalysisManager(BaseManager):
         categorical_features = model_analysis.categorical_features
         inst.__dict__['_categorical_features'] = categorical_features
         target_column = model_analysis.target_column
-        y_train = model_analysis.train[target_column]
-        train = model_analysis.train.drop(columns=[target_column])
-        inst.__dict__['_train'] = train
-        inst.__dict__['_y_train'] = y_train
-        feature_names = list(train.columns)
+        true_y = model_analysis.test[target_column]
+        dataset = model_analysis.test.drop(columns=[target_column])
+        inst.__dict__['_dataset'] = dataset
+        inst.__dict__['_true_y'] = true_y
+        feature_names = list(dataset.columns)
         inst.__dict__['_feature_names'] = feature_names
         inst.__dict__['_analyzer'] = ModelAnalyzer(model_analysis.model,
-                                                   train,
-                                                   y_train,
+                                                   dataset,
+                                                   true_y,
                                                    feature_names,
                                                    categorical_features)
         return inst

--- a/responsibleai/responsibleai/modelanalysis/model_analysis.py
+++ b/responsibleai/responsibleai/modelanalysis/model_analysis.py
@@ -116,7 +116,7 @@ class ModelAnalysis(object):
             target_column=target_column, task_type=task_type,
             categorical_features=categorical_features)
         error_analysis_manager = ErrorAnalysisManager(model,
-                                                      train,
+                                                      test,
                                                       target_column,
                                                       categorical_features)
         self._error_analysis_manager = error_analysis_manager

--- a/responsibleai/tests/error_analysis_validator.py
+++ b/responsibleai/tests/error_analysis_validator.py
@@ -27,13 +27,13 @@ def validate_error_analysis(model_analysis, expected_reports=1):
     for report in reports:
         json_matrix = report.json_matrix
 
-        ea_x_train = model_analysis.error_analysis._train
-        ea_y_train = model_analysis.error_analysis._y_train
+        ea_x_dataset = model_analysis.error_analysis._dataset
+        ea_true_y = model_analysis.error_analysis._true_y
 
-        expected_count = len(ea_x_train)
+        expected_count = len(ea_x_dataset)
         if json_matrix is not None:
-            predictions = model_analysis.model.predict(ea_x_train)
-            expected_false_count = sum(predictions != ea_y_train)
+            predictions = model_analysis.model.predict(ea_x_dataset)
+            expected_false_count = sum(predictions != ea_true_y)
             validate_matrix(json_matrix, expected_count, expected_false_count)
 
         json_tree = report.json_tree


### PR DESCRIPTION
use test data instead of train data for error analysis manager/component in the one model assessment dashboard so the number of points/details/etc look more similar to the other panels (dataset explorer, causal, counterfactual, explanations panels)