### PR TITLE
fix displayed filter order in tree view to start from root node

### DIFF
--- a/libs/core-ui/src/lib/Cohort/PredictionPath/PredictionPath.tsx
+++ b/libs/core-ui/src/lib/Cohort/PredictionPath/PredictionPath.tsx
@@ -24,7 +24,7 @@ export class PredictionPath extends React.Component<IPredictionPathProps> {
     const classNames = predictionPathStyles();
     return (
       <Stack>
-        {filters.map((filter: string, index: number) => (
+        {filters.reverse().map((filter: string, index: number) => (
           <div key={index}>
             <Stack horizontal tokens={alignmentStackTokens}>
               <Stack verticalAlign="center">


### PR DESCRIPTION
Minor fix to change filter order in prediction path to be in same direction as tree view:
![image](https://user-images.githubusercontent.com/24683184/125855499-d145b876-877a-4927-817a-a8783fdf5da4.png)
