### PR TITLE
fix calculating feature importances after error report due to dataframe on analyzer being modified

### DIFF
--- a/erroranalysis/erroranalysis/_internal/cohort_filter.py
+++ b/erroranalysis/erroranalysis/_internal/cohort_filter.py
@@ -23,6 +23,10 @@ def filter_from_cohort(df, filters, composite_filters,
                        pred_y=None):
     if not isinstance(df, pd.DataFrame):
         df = pd.DataFrame(df, columns=feature_names)
+    else:
+        # Note: we make a non-deep copy of the input dataframe since
+        # we will add columns below
+        df = df.copy()
     df[TRUE_Y] = true_y
     if pred_y is not None:
         df[PRED_Y] = pred_y

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '11'
+_patch = '12'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -209,3 +209,7 @@ def create_titanic_pipeline(X_train, y_train):
                            LogisticRegression(solver='lbfgs'))])
     clf.fit(X_train, y_train)
     return clf
+
+
+def create_dataframe(data, feature_names):
+    return pd.DataFrame(data, columns=feature_names)

--- a/erroranalysis/tests/test_error_report.py
+++ b/erroranalysis/tests/test_error_report.py
@@ -1,6 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
 
+import numpy as np
 import pandas as pd
 import pytest
 import uuid
@@ -8,8 +9,9 @@ import uuid
 
 from erroranalysis._internal.error_report import ErrorReport
 from common_utils import (
-    create_boston_data, create_iris_data, create_cancer_data,
-    create_models_classification, create_models_regression)
+    create_boston_data, create_dataframe, create_iris_data,
+    create_cancer_data, create_models_classification,
+    create_models_regression)
 from erroranalysis._internal.error_analyzer import ModelAnalyzer
 
 
@@ -42,6 +44,18 @@ class TestErrorReport(object):
     def test_error_report_boston(self):
         X_train, X_test, y_train, y_test, feature_names = \
             create_boston_data()
+        models = create_models_regression(X_train, y_train)
+
+        for model in models:
+            categorical_features = []
+            run_error_analyzer(model, X_test, y_test, feature_names,
+                               categorical_features)
+
+    def test_error_report_boston_pandas(self):
+        X_train, X_test, y_train, y_test, feature_names = \
+            create_boston_data()
+        X_train = create_dataframe(X_train, feature_names)
+        X_test = create_dataframe(X_test, feature_names)
         models = create_models_regression(X_train, y_train)
 
         for model in models:
@@ -83,7 +97,15 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
     json_str1 = error_report1.to_json()
     json_str2 = error_report2.to_json()
     assert json_str1 != json_str2
+
+    # validate deserialized error report json
     error_report_deserialized = ErrorReport.from_json(json_str1)
     assert error_report_deserialized.id == error_report1.id
     assert error_report_deserialized.json_matrix == error_report1.json_matrix
     assert error_report_deserialized.json_tree == error_report1.json_tree
+
+    # validate error report does not modify original dataset in ModelAnalyzer
+    if isinstance(X_test, pd.DataFrame):
+        assert X_test.equals(model_analyzer.dataset)
+    else:
+        assert np.array_equal(X_test, model_analyzer.dataset)


### PR DESCRIPTION
While debugging another issue in model analysis workflow, I discovered a bug where feature importances failed to calculate.  This was because in model analysis we calculate tree view/matrix filter on error report first, and that modified the original dataset.  Making a non-deep copy (since we just add columns but not change the original data) resolved the issue.