### PR TITLE
add sample_dataset parameter to error analysis to allow it to run on much larger data when no explanation exists

### DIFF
--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -29,7 +29,7 @@ class ErrorAnalysisDashboard(Dashboard):
         (# examples x # features), the same samples used to build the
         explanation. Overwrites any existing dataset on the
         explanation object.
-    :type dataset: numpy.ndarray or list[][]
+    :type dataset: pd.DataFrame or numpy.ndarray or list[][]
     :param true_y: The true labels for the provided explanation. Overwrites
         any existing dataset on the explanation object.
         Note if explanation is sample of dataset, you will need to specify
@@ -74,84 +74,61 @@ class ErrorAnalysisDashboard(Dashboard):
     :param num_leaves: The number of leaves of the surrogate tree
         trained on errors.
     :type num_leaves: int
+    :param sample_dataset: Dataset with fewer samples than the main
+        dataset. Used to improve performance only when an
+        Explanation object is not provided.  Used only if
+        explanation is not specified for the dataset explorer.
+        Specify less than 10k points for optimal performance.
+    :type sample_dataset: pd.DataFrame or numpy.ndarray or list[][]
+
+    :Example:
+
+    # Run simple view of error analysis with just predictions and
+    # true labels
+    >>> predictions = model.predict(X_test)
+    >>> from raiwidgets import ErrorAnalysisDashboard
+    >>> ErrorAnalysisDashboard(dataset=X_test, true_y=y_test,
+    ...                        features=features, pred_y=predictions)
+
+    :Example:
+
+    # Run error analysis with a model and a computed explanation
+    >>> from raiwidgets import ErrorAnalysisDashboard
+    >>> ErrorAnalysisDashboard(global_explanation, model,
+    ...                        dataset=X_test, true_y=y_test)
+
+    :Example:
+
+    # Run error analysis on large data and a downsampled dataset
+    # for the UI
+    >>> from raiwidgets import ErrorAnalysisDashboard
+    >>> ErrorAnalysisDashboard(sample_dataset=X_test_sample,
+    ...                        dataset=X_test,
+    ...                        features=features,
+    ...                        true_y=y_test_sample,
+    ...                        true_y_dataset=y_test,
+    ...                        pred_y=X_test_sample_pred_y,
+    ...                        pred_y_dataset=X_test_pred_y)
     """
 
     def __init__(self, explanation=None, model=None, *, dataset=None,
                  true_y=None, classes=None, features=None, port=None,
                  locale=None, public_ip=None,
                  categorical_features=None, true_y_dataset=None,
-                 pred_y=None, model_task=ModelTask.UNKNOWN,
+                 pred_y=None, pred_y_dataset=None,
+                 model_task=ModelTask.UNKNOWN,
                  metric=None, max_depth=DEFAULT_MAX_DEPTH,
                  num_leaves=DEFAULT_NUM_LEAVES,
-                 min_child_samples=DEFAULT_MIN_CHILD_SAMPLES):
-        """ErrorAnalysis Dashboard Class.
-
-        :param explanation: An object that represents an explanation.
-        :type explanation: ExplanationMixin
-        :param model: An object that represents a model. It is assumed that for
-            the classification case it has a method of predict_proba()
-            returning the prediction probabilities for each class and
-            for the regression case a method of predict() returning the
-            prediction value.
-        :type model: object
-        :param dataset: A matrix of feature vector examples
-            (# examples x # features), the same samples used to build the
-            explanation. Overwrites any existing dataset on the
-            explanation object.
-        :type dataset: numpy.ndarray or list[][]
-        :param true_y: The true labels for the provided explanation. Overwrites
-            any existing dataset on the explanation object.
-            Note if explanation is sample of dataset, you will need to specify
-            true_y_dataset as well.
-        :type true_y: numpy.ndarray or list[]
-        :param classes: The class names.
-        :type classes: numpy.ndarray or list[]
-        :param features: Feature names.
-        :type features: numpy.ndarray or list[]
-        :param port: The port to use on locally hosted service.
-        :type port: int
-        :param public_ip: Optional. If running on a remote vm,
-            the external public ip address of the VM.
-        :type public_ip: str
-        :param categorical_features: The categorical feature names.
-        :type categorical_features: list[str]
-        :param true_y_dataset: The true labels for the provided dataset.
-            Only needed if the explanation has a sample of instances from the
-            original dataset. Otherwise specify true_y parameter only.
-        :type true_y_dataset: numpy.ndarray or list[]
-        :param pred_y: The predicted y values, can be passed in as an
-            alternative to the model and explanation for a more limited
-            view.
-        :type pred_y: numpy.ndarray or list[]
-        :param model_task: Optional parameter to specify whether the model
-            is a classification or regression model. In most cases, the
-            type of the model can be inferred based on the shape of the
-            output, where a classifier has a predict_proba method and
-            outputs a 2 dimensional array, while a regressor has a
-            predict method and outputs a 1 dimensional array.
-        :type model_task: str
-        :param metric: The metric name to evaluate at each tree node or
-            heatmap grid.  Currently supported classification metrics
-            include 'error_rate', 'recall_score', 'precision_score',
-            'f1_score', and 'accuracy_score'. Supported regression
-            metrics include 'mean_absolute_error', 'mean_squared_error',
-            'r2_score', and 'median_absolute_error'.
-        :type metric: str
-        :param max_depth: The maximum depth of the surrogate tree trained
-            on errors.
-        :type max_depth: int
-        :param num_leaves: The number of leaves of the surrogate tree
-            trained on errors.
-        :type num_leaves: int
-        :param min_child_samples: The minimal number of data required
-            to create one leaf.
-        :type min_child_samples: int
-        """
+                 min_child_samples=DEFAULT_MIN_CHILD_SAMPLES,
+                 sample_dataset=None):
+        """Initialize the ErrorAnalysisDashboard."""
         self.input = ErrorAnalysisDashboardInput(
             explanation, model, dataset, true_y, classes,
             features, categorical_features,
-            true_y_dataset, pred_y, model_task, metric,
-            max_depth, num_leaves, min_child_samples)
+            true_y_dataset, pred_y, pred_y_dataset,
+            model_task, metric,
+            max_depth, num_leaves, min_child_samples,
+            sample_dataset)
         super(ErrorAnalysisDashboard, self).__init__(
             dashboard_type="ErrorAnalysis",
             model_data=self.input.dashboard_input,

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -34,11 +34,13 @@ class ErrorAnalysisDashboardInput:
             categorical_features,
             true_y_dataset,
             pred_y,
+            pred_y_dataset,
             model_task,
             metric,
             max_depth,
             num_leaves,
-            min_child_samples):
+            min_child_samples,
+            sample_dataset):
         """Initialize the ErrorAnalysis Dashboard Input.
 
         :param explanation: An object that represents an explanation.
@@ -74,6 +76,11 @@ class ErrorAnalysisDashboardInput:
             alternative to the model and explanation for a more limited
             view.
         :type pred_y: numpy.ndarray or list[]
+        :param pred_y_dataset: The predicted labels for the provided dataset.
+            Only needed if providing a sample dataset for the UI while using
+            the full dataset for the tree view and heatmap. Otherwise specify
+            pred_y parameter only.
+        :type pred_y_dataset: numpy.array or list[]
         :param model_task: Optional parameter to specify whether the model
             is a classification or regression model. In most cases, the
             type of the model can be inferred based on the shape of the
@@ -97,6 +104,12 @@ class ErrorAnalysisDashboardInput:
         :param min_child_samples: The minimal number of data required
             to create one leaf.
         :type min_child_samples: int
+        :param sample_dataset: Dataset with fewer samples than the main
+            dataset. Used to improve performance only when an
+            Explanation object is not provided.  Used only if
+            explanation is not specified for the dataset explorer.
+            Specify less than 10k points for optimal performance.
+        :type sample_dataset: pd.DataFrame or numpy.ndarray or list[][]
         """
         self._model = model
         full_dataset = dataset
@@ -104,6 +117,10 @@ class ErrorAnalysisDashboardInput:
             full_true_y = true_y
         else:
             full_true_y = true_y_dataset
+        if pred_y_dataset is None:
+            full_pred_y = pred_y
+        else:
+            full_pred_y = pred_y_dataset
         self._categorical_features = categorical_features
         self._string_ind_data = None
         self._categories = []
@@ -133,6 +150,8 @@ class ErrorAnalysisDashboardInput:
                 raise ValueError(
                     "Exceeds maximum number of rows"
                     "for visualization (100000)")
+        elif sample_dataset is not None:
+            dataset = sample_dataset
 
         if classes is not None:
             classes = self._convert_to_list(classes)
@@ -243,7 +262,7 @@ class ErrorAnalysisDashboardInput:
             # Assume classification for backwards compatibility
             if model_task == ModelTask.UNKNOWN:
                 model_task = ModelTask.CLASSIFICATION
-            self._error_analyzer = PredictionsAnalyzer(pred_y,
+            self._error_analyzer = PredictionsAnalyzer(full_pred_y,
                                                        full_dataset,
                                                        full_true_y,
                                                        features,
@@ -266,10 +285,8 @@ class ErrorAnalysisDashboardInput:
             else:
                 metric = self._error_analyzer.metric
         if model_available and true_y_dataset is not None:
-            full_predicted_y = self.compute_predicted_y(model, full_dataset)
-        else:
-            full_predicted_y = predicted_y
-        self.set_root_metric(full_predicted_y, full_true_y, metric)
+            full_pred_y = self.compute_predicted_y(model, full_dataset)
+        self.set_root_metric(full_pred_y, full_true_y, metric)
 
     def set_root_metric(self, predicted_y, true_y, metric):
         if metric != Metrics.ERROR_RATE:

--- a/raiwidgets/tests/test_error_analysis_dashboard.py
+++ b/raiwidgets/tests/test_error_analysis_dashboard.py
@@ -66,3 +66,38 @@ class TestErrorAnalysisDashboard:
         knn.fit(X_train, y_train)
         ErrorAnalysisDashboard(model=knn, dataset=X_test,
                                true_y=y_test, classes=classes)
+
+    def test_error_analysis_sample_dataset_with_many_more_rows(self):
+        X, y = make_classification(n_samples=400000)
+
+        # Split data into train and test
+        X_train, X_test, y_train, y_test = train_test_split(X,
+                                                            y,
+                                                            test_size=0.2,
+                                                            random_state=0)
+        classes = np.unique(y_train).tolist()
+        feature_names = ["col" + str(i) for i in list(range(X_train.shape[1]))]
+        X_train = pd.DataFrame(X_train, columns=feature_names)
+        X_test = pd.DataFrame(X_test, columns=feature_names)
+        logreg = sklearn.linear_model.LogisticRegression()
+        logreg.fit(X_train, y_train)
+        _, X_test_sample, _, y_test_sample = train_test_split(X_test,
+                                                              y_test,
+                                                              test_size=0.01,
+                                                              random_state=0)
+        ErrorAnalysisDashboard(model=logreg,
+                               dataset=X_test,
+                               true_y=y_test_sample,
+                               true_y_dataset=y_test,
+                               classes=classes,
+                               sample_dataset=X_test_sample)
+
+        pred_y = logreg.predict(X_test)
+        pred_y_sample = logreg.predict(X_test_sample)
+        ErrorAnalysisDashboard(dataset=X_test,
+                               true_y=y_test_sample,
+                               true_y_dataset=y_test,
+                               classes=classes,
+                               sample_dataset=X_test_sample,
+                               pred_y=pred_y_sample,
+                               pred_y_dataset=pred_y)


### PR DESCRIPTION
Add sample_dataset parameter.  This is in scenario where no explanation is specified (otherwise, the sampled dataset on the explanation is used).  The sampled dataset is passed to the UX and shown in the datasets tab, but the full dataset (specified with "dataset" parameter) is used for the tree view and heatmap.