### PR TITLE
rename json tree and json matrix to just tree and matrix in error report and widgets

### DIFF
--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -8,9 +8,10 @@ from sklearn.compose import ColumnTransformer
 from sklearn.preprocessing import OrdinalEncoder
 from sklearn.feature_selection import (
     mutual_info_classif, mutual_info_regression)
-from erroranalysis._internal.matrix_filter import compute_json_matrix
+from erroranalysis._internal.matrix_filter import (
+    compute_matrix as _compute_matrix)
 from erroranalysis._internal.surrogate_error_tree import (
-    compute_json_error_tree)
+    compute_error_tree as _compute_error_tree)
 from erroranalysis._internal.error_report import ErrorReport
 from erroranalysis._internal.constants import ModelTask, Metrics
 from erroranalysis._internal.version_checker import check_pandas_version
@@ -99,7 +100,7 @@ class BaseAnalyzer(ABC):
         return self._metric
 
     def compute_matrix(self, features, filters, composite_filters):
-        return compute_json_matrix(self, features, filters, composite_filters)
+        return _compute_matrix(self, features, filters, composite_filters)
 
     def compute_error_tree(self,
                            features,
@@ -107,28 +108,28 @@ class BaseAnalyzer(ABC):
                            composite_filters,
                            max_depth=None,
                            num_leaves=None):
-        return compute_json_error_tree(self,
-                                       features,
-                                       filters,
-                                       composite_filters,
-                                       max_depth=max_depth,
-                                       num_leaves=num_leaves)
+        return _compute_error_tree(self,
+                                   features,
+                                   filters,
+                                   composite_filters,
+                                   max_depth=max_depth,
+                                   num_leaves=num_leaves)
 
     def create_error_report(self,
                             filter_features=None,
                             max_depth=None,
                             num_leaves=None):
-        json_tree = self.compute_error_tree(self.feature_names,
-                                            None,
-                                            None,
-                                            max_depth=max_depth,
-                                            num_leaves=num_leaves)
-        json_matrix = None
+        tree = self.compute_error_tree(self.feature_names,
+                                       None,
+                                       None,
+                                       max_depth=max_depth,
+                                       num_leaves=num_leaves)
+        matrix = None
         if filter_features is not None:
-            json_matrix = self.compute_matrix(filter_features,
-                                              None,
-                                              None)
-        return ErrorReport(json_tree, json_matrix)
+            matrix = self.compute_matrix(filter_features,
+                                         None,
+                                         None)
+        return ErrorReport(tree, matrix)
 
     def compute_importances(self):
         input_data = self.dataset

--- a/erroranalysis/erroranalysis/_internal/error_report.py
+++ b/erroranalysis/erroranalysis/_internal/error_report.py
@@ -8,18 +8,18 @@ _ErrorReportVersion = '1.0'
 _AllVersions = [_ErrorReportVersion]
 _VERSION = 'version'
 
-JSON_TREE = 'json_tree'
-JSON_MATRIX = 'json_matrix'
+TREE = 'tree'
+MATRIX = 'matrix'
 ID = 'id'
 METADATA = 'metadata'
 
 
 def json_converter(obj):
-    """Helper function to convert ErrorReport object to json.
+    """Helper function to convert ErrorReport object to a dictionary.
 
-    :param obj: Object to convert to json.
+    :param obj: Object to convert to a dictionary which can be saved as json.
     :type obj: object
-    :return: The converted json.
+    :return: The converted dictionary which can be saved as json.
     :rtype: dict
     """
     if isinstance(obj, ErrorReport):
@@ -31,89 +31,89 @@ def json_converter(obj):
         return obj.__dict__
 
 
-def as_error_report(json_dict):
-    """Helper function to convert json to an ErrorReport object.
+def as_error_report(error_dict):
+    """Helper function to convert a dictionary to an ErrorReport object.
 
-    :param json_dict: The json to convert.
-    :type json_dict: dict
+    :param error_dict: The dictionary to convert.
+    :type error_dict: dict
     :return: The converted ErrorReport.
     :rtype: ErrorReport
     """
-    if METADATA in json_dict:
-        version = json_dict[METADATA].get(_VERSION)
+    if METADATA in error_dict:
+        version = error_dict[METADATA].get(_VERSION)
         if version is None:
             raise ValueError('No version field in the json input')
         elif version not in _AllVersions:
             raise ValueError(
                 "Unknown version in read ErrorReport: {}".format(version))
-        return ErrorReport(json_dict[JSON_TREE],
-                           json_dict[JSON_MATRIX],
-                           json_dict[ID])
+        return ErrorReport(error_dict[TREE],
+                           error_dict[MATRIX],
+                           error_dict[ID])
     else:
-        return json_dict
+        return error_dict
 
 
 class ErrorReport(object):
 
     """Defines the ErrorReport, which contains the tree and matrix filter.
 
-    :param json_tree: The json representation of the tree.
-    :type json_tree: dict
-    :param json_matrix: The json representation of the matrix filter.
-    :type json_matrix: dict
+    :param tree: The representation of the tree.
+    :type tree: dict
+    :param matrix: The representation of the matrix filter.
+    :type matrix: dict
     :param id: The unique identifier for the ErrorReport.
         A new unique id is created if none is specified.
     :type id: str
     """
 
-    def __init__(self, json_tree, json_matrix, id=None):
+    def __init__(self, tree, matrix, id=None):
         """Defines the ErrorReport, which contains the tree and matrix filter.
 
-        :param json_tree: The json representation of the tree.
-        :type json_tree: dict
-        :param json_matrix: The json representation of the matrix filter.
-        :type json_matrix: dict
+        :param tree: The representation of the tree.
+        :type tree: dict
+        :param matrix: The representation of the matrix filter.
+        :type matrix: dict
         :param id: The unique identifier for the ErrorReport.
             A new unique id is created if none is specified.
         :type id: str
         """
         self._id = id or str(uuid.uuid4())
-        self._json_tree = json_tree
-        self._json_matrix = json_matrix
+        self._tree = tree
+        self._matrix = matrix
         self._metadata = {_VERSION: _ErrorReportVersion}
 
     @property
     def __dict__(self):
         """Returns the dictionary representation of the Error Report.
 
-        The dictionary contains the json representation of the tree,
+        The dictionary contains the representation of the tree,
         the matrix filter and any Error Report metadata.
 
         :return: The dictionary representation of the Error Report.
         :rtype: dict
         """
-        return {JSON_TREE: self._json_tree,
-                JSON_MATRIX: self._json_matrix,
+        return {TREE: self._tree,
+                MATRIX: self._matrix,
                 ID: self._id,
                 METADATA: self._metadata}
 
     @property
-    def json_tree(self):
-        """Returns the json representation of the tree.
+    def tree(self):
+        """Returns the representation of the tree.
 
-        :return: The json representation of the tree.
+        :return: The representation of the tree.
         :rtype: dict
         """
-        return self._json_tree
+        return self._tree
 
     @property
-    def json_matrix(self):
-        """Returns the json representation of the matrix filter.
+    def matrix(self):
+        """Returns the representation of the matrix filter.
 
-        :return: The json representation of the matrix filter.
+        :return: The representation of the matrix filter.
         :rtype: dict
         """
-        return self._json_matrix
+        return self._matrix
 
     @property
     def id(self):

--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -29,6 +29,12 @@ VALUES = "values"
 
 
 def compute_json_matrix(analyzer, features, filters, composite_filters):
+    # Note: this is for backcompat for older versions
+    # of raiwidgets pypi package
+    compute_matrix(analyzer, features, filters, composite_filters)
+
+
+def compute_matrix(analyzer, features, filters, composite_filters):
     if features[0] is None and features[1] is None:
         raise ValueError(
             "One or two features must be specified to compute the heat map")
@@ -97,8 +103,8 @@ def compute_json_matrix(analyzer, features, filters, composite_filters):
     else:
         df_err[TRUE_Y] = true_y
         df_err[PRED_Y] = pred_y
-    # construct json matrix
-    json_matrix = []
+    # construct matrix
+    matrix = []
     if len(dataset_sub_names) == 2:
         feat1 = dataset_sub_names[0]
         feat2 = dataset_sub_names[1]
@@ -153,9 +159,9 @@ def compute_json_matrix(analyzer, features, filters, composite_filters):
                                        aggfunc=aggfunc._agg_func_pair)
             matrix_total = matrix_total.fillna(0)
             matrix_error = matrix_error.fillna(0)
-        json_matrix = json_matrix_2d(categories1, categories2,
-                                     matrix_total, matrix_error,
-                                     metric)
+        matrix = matrix_2d(categories1, categories2,
+                           matrix_total, matrix_error,
+                           metric)
     else:
         feat1 = dataset_sub_names[0]
         unique_count1 = len(df[feat1].unique())
@@ -200,9 +206,9 @@ def compute_json_matrix(analyzer, features, filters, composite_filters):
             grouped = cutdf_err.groupby([feat1])
             counts_err = grouped.agg(aggfunc._agg_func_triplet)
             counts_err = counts_err.values.ravel()
-        json_matrix = json_matrix_1d(categories, val_err, counts,
-                                     counts_err, metric)
-    return json_matrix
+        matrix = matrix_1d(categories, val_err, counts,
+                           counts_err, metric)
+    return matrix
 
 
 class _AggFunc(object):
@@ -220,21 +226,21 @@ class _AggFunc(object):
         return self.aggfunc(true_y, pred_y)
 
 
-def json_matrix_2d(categories1, categories2, matrix_counts,
-                   matrix_err_counts, metric):
-    json_matrix = []
-    json_category1 = []
-    json_category1_min_interval = []
-    json_category1_max_interval = []
+def matrix_2d(categories1, categories2, matrix_counts,
+              matrix_err_counts, metric):
+    matrix = []
+    category1 = []
+    category1_min_interval = []
+    category1_max_interval = []
     for row_index in range(len(categories1)):
-        json_matrix_row = []
+        matrix_row = []
         cat1 = categories1[row_index]
         if isinstance(categories1, pd.IntervalIndex):
-            json_category1_min_interval.append(cat1.left)
-            json_category1_max_interval.append(cat1.right)
-            json_category1.append(str(cat1))
+            category1_min_interval.append(cat1.left)
+            category1_max_interval.append(cat1.right)
+            category1.append(str(cat1))
         else:
-            json_category1.append(cat1)
+            category1.append(cat1)
         for col_index in range(len(categories2)):
             cat2 = categories2[col_index]
             index_exists_err = cat1 in matrix_err_counts.index
@@ -253,42 +259,42 @@ def json_matrix_2d(categories1, categories2, matrix_counts,
             if index_exists and col_exists:
                 total_count = int(matrix_counts.loc[cat1, cat2])
             if metric == Metrics.ERROR_RATE:
-                json_matrix_row.append({
+                matrix_row.append({
                     FALSE_COUNT: false_count,
                     COUNT: total_count
                 })
             else:
-                json_matrix_row.append({
+                matrix_row.append({
                     METRIC_VALUE: metric_value,
                     METRIC_NAME: metric_to_display_name[metric],
                     COUNT: total_count
                 })
-        json_matrix.append(json_matrix_row)
+        matrix.append(matrix_row)
 
-    json_category2 = []
-    json_category2_min_interval = []
-    json_category2_max_interval = []
+    category2 = []
+    category2_min_interval = []
+    category2_max_interval = []
     for cat2 in categories2:
         if isinstance(categories2, pd.IntervalIndex):
-            json_category2_min_interval.append(cat2.left)
-            json_category2_max_interval.append(cat2.right)
-            json_category2.append(str(cat2))
+            category2_min_interval.append(cat2.left)
+            category2_max_interval.append(cat2.right)
+            category2.append(str(cat2))
         else:
-            json_category2.append(cat2)
-    category1 = {VALUES: json_category1,
-                 INTERVAL_MIN: json_category1_min_interval,
-                 INTERVAL_MAX: json_category1_max_interval}
-    category2 = {VALUES: json_category2,
-                 INTERVAL_MIN: json_category2_min_interval,
-                 INTERVAL_MAX: json_category2_max_interval}
-    return {MATRIX: json_matrix, CATEGORY1: category1,
+            category2.append(cat2)
+    category1 = {VALUES: category1,
+                 INTERVAL_MIN: category1_min_interval,
+                 INTERVAL_MAX: category1_max_interval}
+    category2 = {VALUES: category2,
+                 INTERVAL_MIN: category2_min_interval,
+                 INTERVAL_MAX: category2_max_interval}
+    return {MATRIX: matrix, CATEGORY1: category1,
             CATEGORY2: category2}
 
 
-def json_matrix_1d(categories, values_err, counts, counts_err,
-                   metric):
-    json_matrix = []
-    json_matrix_row = []
+def matrix_1d(categories, values_err, counts, counts_err,
+              metric):
+    matrix = []
+    matrix_row = []
     for col_idx in range(len(categories)):
         cat = categories[col_idx]
         if metric == Metrics.ERROR_RATE:
@@ -296,7 +302,7 @@ def json_matrix_1d(categories, values_err, counts, counts_err,
             if cat in values_err:
                 index_err = list(values_err).index(cat)
                 false_count = int(counts_err[index_err])
-            json_matrix_row.append({
+            matrix_row.append({
                 FALSE_COUNT: false_count,
                 COUNT: int(counts[col_idx])
             })
@@ -306,23 +312,23 @@ def json_matrix_1d(categories, values_err, counts, counts_err,
                 metric_value = float(counts_err[col_idx])
                 if math.isnan(metric_value):
                     metric_value = 0.0
-            json_matrix_row.append({
+            matrix_row.append({
                 METRIC_VALUE: metric_value,
                 METRIC_NAME: metric_to_display_name[metric],
                 COUNT: int(counts[col_idx])
             })
-    json_matrix.append(json_matrix_row)
-    json_category = []
-    json_category_min_interval = []
-    json_category_max_interval = []
+    matrix.append(matrix_row)
+    category = []
+    category_min_interval = []
+    category_max_interval = []
     for cat in categories:
         if isinstance(categories, pd.IntervalIndex):
-            json_category_min_interval.append(cat.left)
-            json_category_max_interval.append(cat.right)
-            json_category.append(str(cat))
+            category_min_interval.append(cat.left)
+            category_max_interval.append(cat.right)
+            category.append(str(cat))
         else:
-            json_category.append(cat)
-    category1 = {VALUES: json_category,
-                 INTERVAL_MIN: json_category_min_interval,
-                 INTERVAL_MAX: json_category_max_interval}
-    return {MATRIX: json_matrix, CATEGORY1: category1}
+            category.append(cat)
+    category1 = {VALUES: category,
+                 INTERVAL_MIN: category_min_interval,
+                 INTERVAL_MAX: category_max_interval}
+    return {MATRIX: matrix, CATEGORY1: category1}

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '12'
+_patch = '13'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_error_report.py
+++ b/erroranalysis/tests/test_error_report.py
@@ -101,8 +101,8 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
     # validate deserialized error report json
     error_report_deserialized = ErrorReport.from_json(json_str1)
     assert error_report_deserialized.id == error_report1.id
-    assert error_report_deserialized.json_matrix == error_report1.json_matrix
-    assert error_report_deserialized.json_tree == error_report1.json_tree
+    assert error_report_deserialized.matrix == error_report1.matrix
+    assert error_report_deserialized.tree == error_report1.tree
 
     # validate error report does not modify original dataset in ModelAnalyzer
     if isinstance(X_test, pd.DataFrame):

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -198,8 +198,9 @@ def run_error_analyzer(model,
         features = [feature_names[0], feature_names[1]]
     else:
         features = matrix_features
-    json_matrix = error_analyzer.compute_matrix(features, filters,
-                                                composite_filters)
+    matrix = error_analyzer.compute_matrix(features,
+                                           filters,
+                                           composite_filters)
     validation_data = X_test
     if filters is not None or composite_filters is not None:
         validation_data = filter_from_cohort(X_test,
@@ -224,37 +225,37 @@ def run_error_analyzer(model,
     else:
         raise NotImplementedError(
             "Metric {} validation not supported yet".format(metric))
-    validate_matrix(json_matrix,
+    validate_matrix(matrix,
                     expected_count,
                     expected_error,
                     features,
                     metric=metric)
 
 
-def validate_matrix(json_matrix, exp_total_count,
+def validate_matrix(matrix, exp_total_count,
                     exp_total_error,
                     features,
                     metric=Metrics.ERROR_RATE):
-    assert MATRIX in json_matrix
-    assert CATEGORY1 in json_matrix
-    num_cat1 = len(json_matrix[CATEGORY1][VALUES])
+    assert MATRIX in matrix
+    assert CATEGORY1 in matrix
+    num_cat1 = len(matrix[CATEGORY1][VALUES])
     if len(features) == 2:
-        assert len(json_matrix[MATRIX]) == num_cat1
-        assert CATEGORY2 in json_matrix
-        num_cat2 = len(json_matrix[CATEGORY2][VALUES])
-        assert len(json_matrix[MATRIX][0]) == num_cat2
-        validate_matrix_metric(json_matrix, exp_total_count,
+        assert len(matrix[MATRIX]) == num_cat1
+        assert CATEGORY2 in matrix
+        num_cat2 = len(matrix[CATEGORY2][VALUES])
+        assert len(matrix[MATRIX][0]) == num_cat2
+        validate_matrix_metric(matrix, exp_total_count,
                                exp_total_error, metric,
                                num_cat1, num_cat2)
     else:
-        assert len(json_matrix[MATRIX][0]) == num_cat1
-        assert len(json_matrix[MATRIX]) == 1
-        validate_matrix_metric(json_matrix, exp_total_count,
+        assert len(matrix[MATRIX][0]) == num_cat1
+        assert len(matrix[MATRIX]) == 1
+        validate_matrix_metric(matrix, exp_total_count,
                                exp_total_error, metric,
                                1, num_cat1)
 
 
-def validate_matrix_metric(json_matrix, exp_total_count,
+def validate_matrix_metric(matrix, exp_total_count,
                            exp_total_error, metric,
                            num_cat1, num_cat2):
     if metric == Metrics.ERROR_RATE:
@@ -263,8 +264,8 @@ def validate_matrix_metric(json_matrix, exp_total_count,
         total_false_count = 0
         for i in range(num_cat1):
             for j in range(num_cat2):
-                total_count += json_matrix[MATRIX][i][j][COUNT]
-                total_false_count += json_matrix[MATRIX][i][j][FALSE_COUNT]
+                total_count += matrix[MATRIX][i][j][COUNT]
+                total_false_count += matrix[MATRIX][i][j][FALSE_COUNT]
         assert exp_total_count == total_count
         assert exp_total_error == total_false_count
     elif metric == Metrics.MEAN_SQUARED_ERROR:
@@ -273,11 +274,11 @@ def validate_matrix_metric(json_matrix, exp_total_count,
         total_metric_value = 0
         for i in range(num_cat1):
             for j in range(num_cat2):
-                count = json_matrix[MATRIX][i][j][COUNT]
+                count = matrix[MATRIX][i][j][COUNT]
                 total_count += count
-                cell_value = json_matrix[MATRIX][i][j][METRIC_VALUE] * count
+                cell_value = matrix[MATRIX][i][j][METRIC_VALUE] * count
                 total_metric_value += cell_value
-                metric_name = json_matrix[MATRIX][i][j][METRIC_NAME]
+                metric_name = matrix[MATRIX][i][j][METRIC_NAME]
                 assert metric_name == metric_to_display_name[metric]
         total_metric_value = total_metric_value / total_count
         assert exp_total_count == total_count

--- a/erroranalysis/tests/test_surrogate_error_tree.py
+++ b/erroranalysis/tests/test_surrogate_error_tree.py
@@ -70,19 +70,19 @@ class TestSurrogateErrorTree(object):
         filtered_indexed_df[DIFF] = diff
         filtered_indexed_df[TRUE_Y] = y_test
         filtered_indexed_df[PRED_Y] = pred_y
-        json_tree = traverse(filtered_indexed_df,
-                             tree_structure,
-                             max_split_index,
-                             (categories_reindexed,
-                              cat_ind_reindexed),
-                             [],
-                             feature_names,
-                             metric=error_analyzer.metric)
+        tree = traverse(filtered_indexed_df,
+                        tree_structure,
+                        max_split_index,
+                        (categories_reindexed,
+                         cat_ind_reindexed),
+                        [],
+                        feature_names,
+                        metric=error_analyzer.metric)
         # create dictionary from json tree id to values
-        json_tree_dict = {}
-        for entry in json_tree:
-            json_tree_dict[entry['id']] = entry
-        validate_traversed_tree(tree_structure, json_tree_dict,
+        tree_dict = {}
+        for entry in tree:
+            tree_dict[entry['id']] = entry
+        validate_traversed_tree(tree_structure, tree_dict,
                                 max_split_index, feature_names)
 
 
@@ -95,20 +95,20 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
         tree_features = feature_names
     filters = None
     composite_filters = None
-    json_tree = error_analyzer.compute_error_tree(tree_features,
-                                                  filters,
-                                                  composite_filters)
-    assert json_tree is not None
-    assert len(json_tree) > 0
-    assert ERROR in json_tree[0]
-    assert ID in json_tree[0]
-    assert PARENTID in json_tree[0]
-    assert json_tree[0][PARENTID] is None
-    assert SIZE in json_tree[0]
-    assert json_tree[0][SIZE] == len(X_test)
+    tree = error_analyzer.compute_error_tree(tree_features,
+                                             filters,
+                                             composite_filters)
+    assert tree is not None
+    assert len(tree) > 0
+    assert ERROR in tree[0]
+    assert ID in tree[0]
+    assert PARENTID in tree[0]
+    assert tree[0][PARENTID] is None
+    assert SIZE in tree[0]
+    assert tree[0][SIZE] == len(X_test)
 
 
-def validate_traversed_tree(tree, json_tree_dict, max_split_index,
+def validate_traversed_tree(tree, tree_dict, max_split_index,
                             feature_names, parent_id=None):
     if SPLIT_INDEX in tree:
         nodeid = tree[SPLIT_INDEX]
@@ -117,25 +117,25 @@ def validate_traversed_tree(tree, json_tree_dict, max_split_index,
     else:
         nodeid = 0
 
-    assert json_tree_dict[nodeid]['id'] == nodeid
-    assert json_tree_dict[nodeid]['parentId'] == parent_id
+    assert tree_dict[nodeid]['id'] == nodeid
+    assert tree_dict[nodeid]['parentId'] == parent_id
     if SPLIT_FEATURE in tree:
         node_name = feature_names[tree[SPLIT_FEATURE]]
     else:
         node_name = None
-    assert json_tree_dict[nodeid]['nodeName'] == node_name
+    assert tree_dict[nodeid]['nodeName'] == node_name
 
     # validate children
     if 'leaf_value' not in tree:
         left_child = tree[TreeSide.LEFT_CHILD]
         right_child = tree[TreeSide.RIGHT_CHILD]
         validate_traversed_tree(left_child,
-                                json_tree_dict,
+                                tree_dict,
                                 max_split_index,
                                 feature_names,
                                 nodeid)
         validate_traversed_tree(right_child,
-                                json_tree_dict,
+                                tree_dict,
                                 max_split_index,
                                 feature_names,
                                 nodeid)

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -417,12 +417,12 @@ class ErrorAnalysisDashboardInput:
 
     def debug_ml(self, features, filters, composite_filters):
         try:
-            json_tree = self._error_analyzer.compute_error_tree(
+            tree = self._error_analyzer.compute_error_tree(
                 features, filters, composite_filters,
                 max_depth=self._max_depth,
                 num_leaves=self._num_leaves)
             return {
-                WidgetRequestResponseConstants.DATA: json_tree
+                WidgetRequestResponseConstants.DATA: tree
             }
         except Exception as e:
             print(e)
@@ -437,10 +437,10 @@ class ErrorAnalysisDashboardInput:
         try:
             if features[0] is None and features[1] is None:
                 return {WidgetRequestResponseConstants.DATA: []}
-            json_matrix = self._error_analyzer.compute_matrix(
+            matrix = self._error_analyzer.compute_matrix(
                 features, filters, composite_filters)
             return {
-                WidgetRequestResponseConstants.DATA: json_matrix
+                WidgetRequestResponseConstants.DATA: matrix
             }
         except Exception as e:
             print(e)

--- a/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
@@ -56,11 +56,11 @@ class ModelAnalysisDashboardInput:
     def debug_ml(self, data):
         try:
             features, filters, composite_filters, max_depth, num_leaves = data
-            json_tree = self._error_analyzer.compute_error_tree(
+            tree = self._error_analyzer.compute_error_tree(
                 features, filters, composite_filters,
                 max_depth, num_leaves)
             return {
-                WidgetRequestResponseConstants.data: json_tree
+                WidgetRequestResponseConstants.data: tree
             }
         except Exception as e:
             print(e)
@@ -76,10 +76,10 @@ class ModelAnalysisDashboardInput:
             features, filters, composite_filters = data
             if features[0] is None and features[1] is None:
                 return {WidgetRequestResponseConstants.data: []}
-            json_matrix = self._error_analyzer.compute_matrix(
+            matrix = self._error_analyzer.compute_matrix(
                 features, filters, composite_filters)
             return {
-                WidgetRequestResponseConstants.data: json_matrix
+                WidgetRequestResponseConstants.data: matrix
             }
         except Exception as e:
             print(e)

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -6,5 +6,5 @@ jinja2==2.11.3
 ipython==7.16.1
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
-erroranalysis>=0.1.11
+erroranalysis>=0.1.13
 ipykernel<6.0

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,6 +1,6 @@
 dice-ml>=0.6.1,<0.7
 econml==0.12.0b4
-erroranalysis>=0.1.11
+erroranalysis>=0.1.13
 interpret-community>=0.18.1
 lightgbm>=2.0.11
 numpy>=1.17.2

--- a/responsibleai/tests/error_analysis_validator.py
+++ b/responsibleai/tests/error_analysis_validator.py
@@ -25,46 +25,46 @@ def validate_error_analysis(model_analysis, expected_reports=1):
     assert isinstance(reports, list)
     assert len(reports) == expected_reports
     for report in reports:
-        json_matrix = report.json_matrix
+        matrix = report.matrix
 
         ea_x_dataset = model_analysis.error_analysis._dataset
         ea_true_y = model_analysis.error_analysis._true_y
 
         expected_count = len(ea_x_dataset)
-        if json_matrix is not None:
+        if matrix is not None:
             predictions = model_analysis.model.predict(ea_x_dataset)
             expected_false_count = sum(predictions != ea_true_y)
-            validate_matrix(json_matrix, expected_count, expected_false_count)
+            validate_matrix(matrix, expected_count, expected_false_count)
 
-        json_tree = report.json_tree
-        validate_tree(json_tree, expected_count)
+        tree = report.tree
+        validate_tree(tree, expected_count)
 
 
-def validate_matrix(json_matrix, exp_total_count, exp_total_false_count):
-    assert MATRIX in json_matrix
-    assert CATEGORY1 in json_matrix
-    assert CATEGORY2 in json_matrix
-    num_cat1 = len(json_matrix[CATEGORY1][VALUES])
-    num_cat2 = len(json_matrix[CATEGORY2][VALUES])
-    assert len(json_matrix[MATRIX]) == num_cat1
-    assert len(json_matrix[MATRIX][0]) == num_cat2
+def validate_matrix(matrix, exp_total_count, exp_total_false_count):
+    assert MATRIX in matrix
+    assert CATEGORY1 in matrix
+    assert CATEGORY2 in matrix
+    num_cat1 = len(matrix[CATEGORY1][VALUES])
+    num_cat2 = len(matrix[CATEGORY2][VALUES])
+    assert len(matrix[MATRIX]) == num_cat1
+    assert len(matrix[MATRIX][0]) == num_cat2
     # take sum of count, false count
     total_count = 0
     total_false_count = 0
     for i in range(num_cat1):
         for j in range(num_cat2):
-            total_count += json_matrix[MATRIX][i][j][COUNT]
-            total_false_count += json_matrix[MATRIX][i][j][FALSE_COUNT]
+            total_count += matrix[MATRIX][i][j][COUNT]
+            total_false_count += matrix[MATRIX][i][j][FALSE_COUNT]
     assert exp_total_count == total_count
     assert exp_total_false_count == total_false_count
 
 
-def validate_tree(json_tree, expected_count):
-    assert json_tree is not None
-    assert len(json_tree) > 0
-    assert ERROR in json_tree[0]
-    assert ID in json_tree[0]
-    assert PARENTID in json_tree[0]
-    assert json_tree[0][PARENTID] is None
-    assert SIZE in json_tree[0]
-    assert json_tree[0][SIZE] == expected_count
+def validate_tree(tree, expected_count):
+    assert tree is not None
+    assert len(tree) > 0
+    assert ERROR in tree[0]
+    assert ID in tree[0]
+    assert PARENTID in tree[0]
+    assert tree[0][PARENTID] is None
+    assert SIZE in tree[0]
+    assert tree[0][SIZE] == expected_count


### PR DESCRIPTION
rename json_tree to just tree and json_matrix to just matrix in both error analysis and raiwidgets packages, as well as all tests and related code (since it's actually a dictionary structure and not a json string)