### PR TITLE
add matrix features and tree features to error report

### DIFF
--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -129,7 +129,9 @@ class BaseAnalyzer(ABC):
             matrix = self.compute_matrix(filter_features,
                                          None,
                                          None)
-        return ErrorReport(tree, matrix)
+        return ErrorReport(tree, matrix,
+                           tree_features=self.feature_names,
+                           matrix_features=filter_features)
 
     def compute_importances(self):
         input_data = self.dataset

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '13'
+_patch = '14'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_error_report.py
+++ b/erroranalysis/tests/test_error_report.py
@@ -99,10 +99,12 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
     assert json_str1 != json_str2
 
     # validate deserialized error report json
-    error_report_deserialized = ErrorReport.from_json(json_str1)
-    assert error_report_deserialized.id == error_report1.id
-    assert error_report_deserialized.matrix == error_report1.matrix
-    assert error_report_deserialized.tree == error_report1.tree
+    ea_deserialized = ErrorReport.from_json(json_str1)
+    assert ea_deserialized.id == error_report1.id
+    assert ea_deserialized.matrix == error_report1.matrix
+    assert ea_deserialized.tree == error_report1.tree
+    assert ea_deserialized.tree_features == error_report1.tree_features
+    assert ea_deserialized.matrix_features == error_report1.matrix_features
 
     # validate error report does not modify original dataset in ModelAnalyzer
     if isinstance(X_test, pd.DataFrame):

--- a/responsibleai/tests/error_analysis_validator.py
+++ b/responsibleai/tests/error_analysis_validator.py
@@ -5,6 +5,8 @@ import pytest
 from erroranalysis._internal.matrix_filter import (
     CATEGORY1, CATEGORY2, COUNT, FALSE_COUNT, MATRIX, VALUES)
 from responsibleai.exceptions import DuplicateManagerConfigException
+from responsibleai._internal.constants import (
+    ErrorAnalysisManagerKeys as Keys)
 
 SIZE = 'size'
 PARENTID = 'parentId'
@@ -24,8 +26,14 @@ def validate_error_analysis(model_analysis, expected_reports=1):
     reports = model_analysis.error_analysis.get()
     assert isinstance(reports, list)
     assert len(reports) == expected_reports
-    for report in reports:
+    ea_info_list = model_analysis.error_analysis.list()
+    for idx, report in enumerate(reports):
         matrix = report.matrix
+        matrix_features = report.matrix_features
+        tree_features = report.tree_features
+        info_features = ea_info_list[Keys.REPORTS][idx][Keys.FILTER_FEATURES]
+        assert matrix_features == info_features
+        assert tree_features == model_analysis.error_analysis._feature_names
 
         ea_x_dataset = model_analysis.error_analysis._dataset
         ea_true_y = model_analysis.error_analysis._true_y


### PR DESCRIPTION
- added matrix features to ErrorReport, which are the one or two features selected for creating the matrix filter (aka heatmap)
- added tree_features to ErrorReport, which are the features that were selected to train the decision tree on errors
- made the new properties optional on ErrorReport so this is not a breaking change (won't break builds)