### PR TITLE
fix serialize_json_safe not escaping special characters which caused dashboard to fail to render on pandas dataframe that had double quotes in string values

### DIFF
--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -248,7 +248,7 @@ class ErrorAnalysisDashboardInput:
         if self._categorical_features:
             self.dashboard_input[
                 ExplanationDashboardInterface.CATEGORICAL_MAP
-            ] = self._error_analyzer.category_dictionary
+            ] = serialize_json_safe(self._error_analyzer.category_dictionary)
         # Compute metrics on all data cohort
         if self._error_analyzer.model_task == ModelTask.CLASSIFICATION:
             if self._error_analyzer.metric is None:

--- a/responsibleai/responsibleai/serialization_utilities.py
+++ b/responsibleai/responsibleai/serialization_utilities.py
@@ -5,11 +5,12 @@ import datetime
 import numpy as np
 
 from typing import Any
+import json
 
 
 def serialize_json_safe(o: Any):
     """
-    Convert a value into something that is safe to parse into JSON.
+    Convert a value into something that is safe to parse as JSON.
 
     :param o: Object to make JSON safe.
     :return: Serialized object.
@@ -18,6 +19,10 @@ def serialize_json_safe(o: Any):
         if isinstance(o, float):
             if np.isinf(o) or np.isnan(o):
                 return 0
+        # need to escape double quoted string values
+        # and other special characters for json
+        if isinstance(o, str):
+            return json.dumps(o)[1:-1]
         return o
     elif isinstance(o, datetime.datetime):
         return o.__str__()

--- a/responsibleai/tests/test_serialization_utilities.py
+++ b/responsibleai/tests/test_serialization_utilities.py
@@ -4,6 +4,7 @@
 import numpy as np
 
 from responsibleai.serialization_utilities import serialize_json_safe
+import json
 
 
 class TestSerializationUtilities:
@@ -28,3 +29,15 @@ class TestSerializationUtilities:
         c = complex(1, 2)
         result = serialize_json_safe([c, 42])
         assert result == [c, 42]
+
+    def test_strings_with_special_chars(self):
+        special_chars_dict = {"hello": "world\"with\"quotes",
+                              "hi": ["a", "list", "of",
+                                     "special\t\"\r\nblah",
+                                     "chars"]}
+        result = json.dumps(special_chars_dict, default=serialize_json_safe)
+        assert result == ("{\"hello\": \"world\\\"with\\\"quotes\", " +
+                          "\"hi\": [\"a\", \"list\", \"of\", " +
+                          "\"special\\t\\\"\\r\\nblah\", \"chars\"]}")
+        deserialized_special_chars_dict = json.loads(result)
+        assert special_chars_dict == deserialized_special_chars_dict


### PR DESCRIPTION
- fix for customer that had issue running error analysis dashboard on a pandas dataframe that had double quotes in it
- fixes serialize_json_safe not escaping special characters which caused dashboard to fail to render on pandas dataframe that had double quotes in string values
- also call serialize_json_safe on categorical map parameter passed in error analysis dashboard