### PR TITLE
Fix aggregate feature importance chart for multiclass classification

### DIFF
--- a/apps/dashboard-e2e/src/describer/interpret/IInterpretData.ts
+++ b/apps/dashboard-e2e/src/describer/interpret/IInterpretData.ts
@@ -15,4 +15,7 @@ export interface IInterpretData {
   noY?: boolean;
   isClassification?: boolean;
   isMulticlass?: boolean;
+  aggregateFeatureImportanceExpectedValues?: {
+    [key: string]: number;
+  };
 }

--- a/apps/dashboard-e2e/src/describer/interpret/aggregateFeatureImportance/describeAggregateFeatureImportance.ts
+++ b/apps/dashboard-e2e/src/describer/interpret/aggregateFeatureImportance/describeAggregateFeatureImportance.ts
@@ -4,7 +4,10 @@
 import { getMenu } from "../../../util/getMenu";
 import { interpretDatasets } from "../interpretDatasets";
 
-import { describeGlobalExplanationBarChart } from "./describeGlobalExplanationBarChart";
+import {
+  describeGlobalExplanationBarChart,
+  describeGlobalExplanationBarChartExplicitValues
+} from "./describeGlobalExplanationBarChart";
 import { describeGlobalExplanationBoxChart } from "./describeGlobalExplanationBoxChart";
 
 const testName = "Aggregate feature importance";
@@ -22,6 +25,9 @@ export function describeAggregateFeatureImportance(
       getMenu("Aggregate feature importance", "#DashboardPivot").click();
     });
     describeGlobalExplanationBarChart(datasetShape);
+    if (datasetShape.aggregateFeatureImportanceExpectedValues) {
+      describeGlobalExplanationBarChartExplicitValues(datasetShape);
+    }
     if (!datasetShape.noLocalImportance) {
       describeGlobalExplanationBoxChart(datasetShape);
     }

--- a/apps/dashboard-e2e/src/describer/interpret/aggregateFeatureImportance/describeGlobalExplanationBarChart.ts
+++ b/apps/dashboard-e2e/src/describer/interpret/aggregateFeatureImportance/describeGlobalExplanationBarChart.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { selectDropdown } from "apps/dashboard-e2e/src/util/dropdown";
+
 import { BarChart } from "../../../util/BarChart";
 import { IInterpretData } from "../IInterpretData";
 
@@ -20,6 +22,23 @@ export function describeGlobalExplanationBarChart(
     it("should be sorted by height", () => {
       expect(props.chart.sortByH()).deep.equal(props.chart.Elements);
     });
+
     describeGlobalExplanationChart(props);
+  });
+}
+
+export function describeGlobalExplanationBarChartExplicitValues(
+  dataShape: IInterpretData
+): void {
+  describe("Bar chart - explicit values", () => {
+    it("should have expected explanation values", () => {
+      for (const classWeightKey in dataShape.aggregateFeatureImportanceExpectedValues) {
+        selectDropdown("#classWeightDropdown", classWeightKey);
+        cy.get("#FeatureImportanceBar").should(
+          "contain.text",
+          dataShape.aggregateFeatureImportanceExpectedValues?.[classWeightKey]
+        );
+      }
+    });
   });
 }

--- a/apps/dashboard-e2e/src/describer/interpret/interpretDatasets.ts
+++ b/apps/dashboard-e2e/src/describer/interpret/interpretDatasets.ts
@@ -282,6 +282,12 @@ const interpretDatasets = {
     isClassification: true
   },
   irisData: {
+    aggregateFeatureImportanceExpectedValues: {
+      "Average of absolute value": 0.329,
+      "Class: setosa": 0.387,
+      "Class: versicolor": 0.365,
+      "Class: virginica": 0.236
+    },
     datapoint: 30,
     datasetBarLabel: ["0 - 5", "6 - 11", "12 - 17", "18 - 23", "24 - 29"],
     defaultXAxis: "Index",

--- a/apps/dashboard-e2e/src/util/dropdown.ts
+++ b/apps/dashboard-e2e/src/util/dropdown.ts
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { getSpan } from "./getSpan";
+
+export function selectDropdown(selector: string, item: string | number): void {
+  cy.get(`${selector}`).click();
+  getSpan(item.toString()).click();
+}

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
@@ -66,7 +66,6 @@ interface IGlobalExplanationTabState {
   globalBarSettings?: IGlobalBarSettings;
   dependenceProps?: IGenericChartProps;
   cohortSeries: IGlobalSeries[];
-  activeSeries: IGlobalSeries[];
 }
 
 export class GlobalExplanationTab extends React.PureComponent<
@@ -92,7 +91,6 @@ export class GlobalExplanationTab extends React.PureComponent<
       initialCohortIndex = this.props.initialCohortIndex;
     }
     this.state = {
-      activeSeries: [],
       chartType: ChartTypes.Bar,
       cohortSeries: [],
       selectedCohortIndex: initialCohortIndex,
@@ -116,10 +114,6 @@ export class GlobalExplanationTab extends React.PureComponent<
 
     const cohortSeries = this.getGlobalSeries();
     this.setState({
-      activeSeries: this.getActiveCohortSeries(
-        sortArray.map(() => true),
-        cohortSeries
-      ),
       cohortSeries,
       globalBarSettings: this.getDefaultSettings(),
       sortArray
@@ -214,7 +208,7 @@ export class GlobalExplanationTab extends React.PureComponent<
             chartType={this.state.chartType}
             unsortedX={this.context.modelMetadata.featureNamesAbridged}
             originX={this.context.modelMetadata.featureNames}
-            unsortedSeries={this.state.activeSeries}
+            unsortedSeries={this.getActiveCohortSeries(this.state.seriesIsActive)}
             topK={this.state.topK}
             onFeatureSelection={this.handleFeatureSelection}
             selectedFeatureIndex={this.state.selectedFeatureIndex}
@@ -330,7 +324,6 @@ export class GlobalExplanationTab extends React.PureComponent<
     const seriesIsActive = [...this.state.seriesIsActive];
     seriesIsActive[index] = !seriesIsActive[index];
     this.setState({
-      activeSeries: this.getActiveCohortSeries(seriesIsActive),
       seriesIsActive
     });
   };
@@ -367,7 +360,6 @@ export class GlobalExplanationTab extends React.PureComponent<
     }
     const seriesIsActive: boolean[] = this.props.cohorts.map(() => true);
     this.setState({
-      activeSeries: this.getActiveCohortSeries(seriesIsActive),
       cohortSeries: this.getGlobalSeries(),
       selectedCohortIndex,
       seriesIsActive

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/GlobalExplanationTab.tsx
@@ -208,7 +208,9 @@ export class GlobalExplanationTab extends React.PureComponent<
             chartType={this.state.chartType}
             unsortedX={this.context.modelMetadata.featureNamesAbridged}
             originX={this.context.modelMetadata.featureNames}
-            unsortedSeries={this.getActiveCohortSeries(this.state.seriesIsActive)}
+            unsortedSeries={this.getActiveCohortSeries(
+              this.state.seriesIsActive
+            )}
             topK={this.state.topK}
             onFeatureSelection={this.handleFeatureSelection}
             selectedFeatureIndex={this.state.selectedFeatureIndex}

--- a/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/SidePanel.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/Controls/GlobalExplanationTab/SidePanel.tsx
@@ -124,6 +124,7 @@ export class SidePanel extends React.Component<
                 </ul>
               </LabelWithCallout>
               <Dropdown
+                id={"classWeightDropdown"}
                 options={this.state.weightOptions}
                 selectedKey={this.props.selectedWeightVector}
                 onChange={this.setWeightOption}


### PR DESCRIPTION
`activeSeries` is only referenced once, so we don't need to keep it in the state and instead calculate it on the fly when needed.

The aggregate in the test case have been calculated by me to ensure they're correct. Still, these need to be expanded to cover other scenarios in the future. 