### PR TITLE
Causal treatment costs per feature/sample/category

### DIFF
--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -2,7 +2,10 @@
 # Licensed under the MIT License.
 
 """Manager for causal analysis."""
+import numpy as np
 import pandas as pd
+
+from typing import Any, List, Optional, Union
 
 from econml.solutions.causal_analysis import CausalAnalysis
 from pathlib import Path
@@ -47,20 +50,29 @@ class CausalManager(BaseManager):
 
     def add(
         self,
-        treatment_features,
-        heterogeneity_features=None,
-        nuisance_model=ModelTypes.LINEAR,
-        heterogeneity_model=ModelTypes.LINEAR,
-        alpha=DefaultParams.DEFAULT_ALPHA,
-        upper_bound_on_cat_expansion=DefaultParams.DEFAULT_MAX_CAT_EXPANSION,
-        treatment_cost=DefaultParams.DEFAULT_TREATMENT_COST,
-        min_tree_leaf_samples=DefaultParams.DEFAULT_MIN_TREE_LEAF_SAMPLES,
-        max_tree_depth=DefaultParams.DEFAULT_MAX_TREE_DEPTH,
-        skip_cat_limit_checks=DefaultParams.DEFAULT_SKIP_CAT_LIMIT_CHECKS,
-        categories=DefaultParams.DEFAULT_CATEGORIES,
-        n_jobs=DefaultParams.DEFAULT_N_JOBS,
-        verbose=DefaultParams.DEFAULT_VERBOSE,
-        random_state=DefaultParams.DEFAULT_RANDOM_STATE,
+        treatment_features: List[str],
+        heterogeneity_features: Optional[List[str]] = None,
+        nuisance_model: str = ModelTypes.LINEAR,
+        heterogeneity_model: str = ModelTypes.LINEAR,
+        alpha: float = DefaultParams.DEFAULT_ALPHA,
+        upper_bound_on_cat_expansion: int = (
+            DefaultParams.DEFAULT_MAX_CAT_EXPANSION),
+        treatment_cost: Union[float, List[Union[float, np.ndarray]]] = (
+            DefaultParams.DEFAULT_TREATMENT_COST),
+        min_tree_leaf_samples: int = (
+            DefaultParams.DEFAULT_MIN_TREE_LEAF_SAMPLES),
+        max_tree_depth: int = (
+            DefaultParams.DEFAULT_MAX_TREE_DEPTH),
+        skip_cat_limit_checks: bool = (
+            DefaultParams.DEFAULT_SKIP_CAT_LIMIT_CHECKS),
+        categories: Union[str, List[Union[str, List[Any]]]] = (
+            DefaultParams.DEFAULT_CATEGORIES),
+        n_jobs: int = (
+            DefaultParams.DEFAULT_N_JOBS),
+        verbose: int = (
+            DefaultParams.DEFAULT_VERBOSE),
+        random_state: Optional[Union[int, np.random.RandomState]] = (
+            DefaultParams.DEFAULT_RANDOM_STATE),
     ):
         """Compute causal insights.
         :param treatment_features: Treatment feature names.
@@ -77,19 +89,25 @@ class CausalManager(BaseManager):
         :param upper_bound_on_cat_expansion: Maximum expansion for
                                              categorical features.
         :type upper_bound_on_cat_expansion: int
-        :param treatment_cost: Cost to treat one individual or
-                               per-individual costs as an array.
-        :type treatment_cost: float or array
+        :param treatment_cost: Cost of treatment. If 0 all treatments will
+            have zero cost. If a list is passed then each element will be
+            applied to each treatment feature. Each element can be a scalar
+            value to indicate a constant cost of applying that treatment or
+            an array indicating the cost for each sample. If the treatment
+            is a discrete treatment then the array for that feature should
+            be two dimensional wih the first dimension representing samples
+            and t second representing the difference in cost between the
+            non-default values and the default value.
+        :type treatment_cost: None, List of float or array
         :param min_tree_leaf_samples: Minimum number of samples per leaf
-                                      in policy tree.
+            in policy tree.
         :type min_tree_leaf_samples: int
         :param max_tree_depth: Maximum depth of policy tree.
         :type max_tree_depth: int
-        :param skip_cat_limit_checks: By default, categorical features need
-                                      to have several instances of each
-                                      category in order for a model to be
-                                      fit robustly. Setting this to True
-                                      will skip these checks.
+        :param skip_cat_limit_checks:
+            By default, categorical features need to have several instances
+            of each category in order for a model to be fit robustly.
+            Setting this to True will skip these checks.
         :type skip_cat_limit_checks: bool
         :param categories: 'auto' or list of category values, default 'auto'
             What categories to use for the categorical columns.
@@ -109,6 +127,8 @@ class CausalManager(BaseManager):
         :type verbose: int
         :param random_state: Controls the randomness of the estimator.
         :type random_state: int or RandomState or None
+        :return: Causal result.
+        :rtype: CausalResult
         """
         difference_set = set(treatment_features) - set(self._train.columns)
         if len(difference_set) > 0:
@@ -182,13 +202,40 @@ class CausalManager(BaseManager):
             X_test, alpha=alpha, keep_all_levels=True)
 
         result.policies = []
-        for treatment_feature in treatment_features:
+
+        # Check treatment_cost is valid
+        if isinstance(treatment_cost, int) and treatment_cost == 0:
+            treatment_cost = [0] * len(treatment_features)
+
+        if not isinstance(treatment_cost, list):
+            message = ("treatment_cost must be a list with "
+                       "the same number of elements as "
+                       "treatment_features where each element "
+                       "is either a constant cost of treatment "
+                       "or an array specifying the cost of "
+                       "treatment per sample. "
+                       "Found treatment_cost of type "
+                       f"{type(treatment_cost)}, expected list.")
+            raise ValueError(message)
+        elif len(treatment_cost) != len(treatment_features):
+            message = ("treatment_cost must be a list with "
+                       "the same number of elements as "
+                       "treatment_features. "
+                       "Length of treatment_cost was "
+                       f"{len(treatment_cost)}, expected "
+                       f"{len(treatment_features)}.")
+            raise ValueError(message)
+
+        for i in range(len(treatment_features)):
+            treatment_feature = treatment_features[i]
+            cost = 0 if treatment_cost is None else treatment_cost[i]
             policy = self._create_policy(
                 analysis, X_test,
-                treatment_feature, treatment_cost,
+                treatment_feature, cost,
                 alpha, max_tree_depth, min_tree_leaf_samples)
             result.policies.append(policy)
         self._results.append(result)
+        return result
 
     def _fit_causal_analysis(
         self,

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -227,11 +227,9 @@ class CausalManager(BaseManager):
             raise ValueError(message)
 
         for i in range(len(treatment_features)):
-            treatment_feature = treatment_features[i]
-            cost = 0 if treatment_cost is None else treatment_cost[i]
             policy = self._create_policy(
                 analysis, X_test,
-                treatment_feature, cost,
+                treatment_features[i], treatment_cost[i],
                 alpha, max_tree_depth, min_tree_leaf_samples)
             result.policies.append(policy)
         self._results.append(result)

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -12,8 +12,7 @@ from pathlib import Path
 
 from responsibleai._internal.constants import ManagerNames
 from responsibleai._managers.base_manager import BaseManager
-from responsibleai.exceptions import (
-    UserConfigValidationException)
+from responsibleai.exceptions import UserConfigValidationException
 from responsibleai._tools.causal.causal_constants import (
     DefaultParams, ModelTypes, ResultAttributes, SerializationAttributes)
 from responsibleai._tools.causal.causal_config import CausalConfig
@@ -89,12 +88,12 @@ class CausalManager(BaseManager):
         :param upper_bound_on_cat_expansion: Maximum expansion for
                                              categorical features.
         :type upper_bound_on_cat_expansion: int
-        :param treatment_cost: Cost of treatment. If 0 all treatments will
-            have zero cost. If a list is passed then each element will be
+        :param treatment_cost: Cost of treatment. If 0, all treatments will
+            have zero cost. If a list is passed, then each element will be
             applied to each treatment feature. Each element can be a scalar
             value to indicate a constant cost of applying that treatment or
             an array indicating the cost for each sample. If the treatment
-            is a discrete treatment then the array for that feature should
+            is a discrete treatment, then the array for that feature should
             be two dimensional wih the first dimension representing samples
             and t second representing the difference in cost between the
             non-default values and the default value.
@@ -216,7 +215,7 @@ class CausalManager(BaseManager):
                        "treatment per sample. "
                        "Found treatment_cost of type "
                        f"{type(treatment_cost)}, expected list.")
-            raise ValueError(message)
+            raise UserConfigValidationException(message)
         elif len(treatment_cost) != len(treatment_features):
             message = ("treatment_cost must be a list with "
                        "the same number of elements as "
@@ -224,7 +223,7 @@ class CausalManager(BaseManager):
                        "Length of treatment_cost was "
                        f"{len(treatment_cost)}, expected "
                        f"{len(treatment_features)}.")
-            raise ValueError(message)
+            raise UserConfigValidationException(message)
 
         for i in range(len(treatment_features)):
             policy = self._create_policy(

--- a/responsibleai/tests/test_causal/test_causal_manager.py
+++ b/responsibleai/tests/test_causal/test_causal_manager.py
@@ -9,6 +9,7 @@ from unittest.mock import patch, ANY
 from ..common_utils import create_boston_data
 
 from responsibleai import ModelAnalysis, ModelTask
+from responsibleai.exceptions import UserConfigValidationException
 from responsibleai._managers.causal_manager import CausalManager
 
 
@@ -94,7 +95,7 @@ class TestCausalManagerTreatmentCosts:
                    "or an array specifying the cost of treatment per "
                    "sample. Found treatment_cost "
                    "of type <class 'int'>, expected list.")
-        with pytest.raises(ValueError, match=message):
+        with pytest.raises(UserConfigValidationException, match=message):
             cost_manager.add(['ZN', 'RM', 'B'], treatment_cost=5)
 
     def test_nonlist_cost(self, cost_manager):
@@ -104,7 +105,7 @@ class TestCausalManagerTreatmentCosts:
                    "specifying the cost of treatment per sample. "
                    "Found treatment_cost of type <class 'numpy.ndarray'>, "
                    "expected list.")
-        with pytest.raises(ValueError, match=message):
+        with pytest.raises(UserConfigValidationException, match=message):
             cost_manager.add(['ZN', 'RM', 'B'],
                              treatment_cost=np.array([1, 2]))
 
@@ -112,7 +113,7 @@ class TestCausalManagerTreatmentCosts:
         expected = ("treatment_cost must be a list with the same number of "
                     "elements as treatment_features. "
                     "Length of treatment_cost was 2, expected 3.")
-        with pytest.raises(ValueError, match=expected):
+        with pytest.raises(UserConfigValidationException, match=expected):
             cost_manager.add(['ZN', 'RM', 'B'], treatment_cost=[1, 2])
 
     def test_constant_cost_per_treatment_feature(self, cost_manager):
@@ -141,6 +142,6 @@ class TestCausalManagerTreatmentCosts:
             np.array([1, 2, 3, 4, 5]),
             np.array([2, 3, 4, 5, 1]),
         ]
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             cost_manager.add(['ZN', 'B'], treatment_cost=costs,
                              skip_cat_limit_checks=True)

--- a/responsibleai/tests/test_causal/test_causal_manager.py
+++ b/responsibleai/tests/test_causal/test_causal_manager.py
@@ -1,12 +1,15 @@
 # Copyright (c) Microsoft Corporation
 # Licensed under the MIT License.
+import numpy as np
 import pytest
-
 import pandas as pd
+
+from unittest.mock import patch, ANY
 
 from ..common_utils import create_boston_data
 
 from responsibleai import ModelAnalysis, ModelTask
+from responsibleai._managers.causal_manager import CausalManager
 
 
 @pytest.fixture(scope='module')
@@ -24,33 +27,24 @@ class TestCausalManager:
     def test_causal_no_categoricals(self, boston_data):
         train_df, test_df, feature_names, target_feature = boston_data
 
-        categoricals = None
-        task = ModelTask.REGRESSION
-        analysis = ModelAnalysis(
-            None, train_df, test_df, target_feature, task,
-            categorical_features=categoricals)
+        manager = CausalManager(train_df, test_df, target_feature,
+                                ModelTask.REGRESSION, None)
 
-        treatment_features = ['ZN']
-        analysis.causal.add(treatment_features=treatment_features)
-        results = analysis.causal.get()
+        result = manager.add(['ZN'])
 
-        assert len(results) == 1
-        assert len(results[0].policies) == 1
-        assert len(results[0].config.treatment_features) == 1
-        assert results[0].config.treatment_features[0] == 'ZN'
+        assert len(result.policies) == 1
+        assert len(result.config.treatment_features) == 1
+        assert result.config.treatment_features[0] == 'ZN'
 
     def test_causal_save_and_load(self, boston_data, tmpdir):
         train_df, test_df, feature_names, target_feature = boston_data
 
         save_dir = tmpdir.mkdir('save-dir')
 
-        model = None
-        task = ModelTask.REGRESSION
         analysis = ModelAnalysis(
-            model, train_df, test_df, target_feature, task)
+            None, train_df, test_df, target_feature, ModelTask.REGRESSION)
 
-        treatment_features = ['ZN']
-        analysis.causal.add(treatment_features=treatment_features)
+        analysis.causal.add(['ZN'])
         pre_results = analysis.causal.get()
         pre_result = pre_results[0]
 
@@ -67,14 +61,86 @@ class TestCausalManager:
     def test_causal_cat_expansion(self, boston_data):
         train_df, test_df, feature_names, target_feature = boston_data
 
-        model = None
-        task = ModelTask.REGRESSION
-        analysis = ModelAnalysis(
-            model, train_df, test_df, target_feature, task,
-            categorical_features=['ZN'])
-
-        treatment_features = ['ZN']
+        manager = CausalManager(train_df, test_df, target_feature,
+                                ModelTask.REGRESSION, ['ZN'])
 
         expected = "Increase the value 50"
         with pytest.raises(ValueError, match=expected):
-            analysis.causal.add(treatment_features=treatment_features)
+            manager.add(['ZN'])
+
+
+@pytest.fixture(scope='class')
+def cost_manager(boston_data):
+    train_df, test_df, feature_names, target_feature = boston_data
+
+    test_df = test_df[:7]
+    return CausalManager(train_df, test_df, target_feature,
+                         ModelTask.REGRESSION, ['CHAS'])
+
+
+class TestCausalManagerTreatmentCosts:
+    def test_zero_cost(self, cost_manager):
+        with patch.object(cost_manager, '_create_policy', return_value=None)\
+                as mock_create:
+            cost_manager.add(['ZN', 'RM', 'B'], treatment_cost=0)
+            mock_create.assert_any_call(ANY, ANY, 'ZN', 0, ANY, ANY, ANY)
+            mock_create.assert_any_call(ANY, ANY, 'RM', 0, ANY, ANY, ANY)
+            mock_create.assert_any_call(ANY, ANY, 'B', 0, ANY, ANY, ANY)
+
+    def test_nonzero_scalar_cost(self, cost_manager):
+        message = ("treatment_cost must be a list with the same number "
+                   "of elements as treatment_features where each "
+                   "element is either a constant cost of treatment "
+                   "or an array specifying the cost of treatment per "
+                   "sample. Found treatment_cost "
+                   "of type <class 'int'>, expected list.")
+        with pytest.raises(ValueError, match=message):
+            cost_manager.add(['ZN', 'RM', 'B'], treatment_cost=5)
+
+    def test_nonlist_cost(self, cost_manager):
+        message = ("treatment_cost must be a list with the same number of "
+                   "elements as treatment_features where each element is "
+                   "either a constant cost of treatment or an array "
+                   "specifying the cost of treatment per sample. "
+                   "Found treatment_cost of type <class 'numpy.ndarray'>, "
+                   "expected list.")
+        with pytest.raises(ValueError, match=message):
+            cost_manager.add(['ZN', 'RM', 'B'],
+                             treatment_cost=np.array([1, 2]))
+
+    def test_invalid_cost_list_length(self, cost_manager):
+        expected = ("treatment_cost must be a list with the same number of "
+                    "elements as treatment_features. "
+                    "Length of treatment_cost was 2, expected 3.")
+        with pytest.raises(ValueError, match=expected):
+            cost_manager.add(['ZN', 'RM', 'B'], treatment_cost=[1, 2])
+
+    def test_constant_cost_per_treatment_feature(self, cost_manager):
+        with patch.object(cost_manager, '_create_policy', return_value=None)\
+                as mock_create:
+            cost_manager.add(['ZN', 'RM', 'B'], treatment_cost=[1, 2, 3])
+            mock_create.assert_any_call(ANY, ANY, 'ZN', 1, ANY, ANY, ANY)
+            mock_create.assert_any_call(ANY, ANY, 'RM', 2, ANY, ANY, ANY)
+            mock_create.assert_any_call(ANY, ANY, 'B', 3, ANY, ANY, ANY)
+
+    def test_per_sample_costs(self, cost_manager):
+        with patch.object(cost_manager, '_create_policy', return_value=None)\
+                as mock_create:
+            costs = [
+                [1, 2, 3, 4, 5, 6, 7],
+                [2, 3, 4, 5, 6, 7, 1],
+            ]
+            cost_manager.add(['ZN', 'RM'], treatment_cost=costs)
+            mock_create.assert_any_call(
+                ANY, ANY, 'ZN', [1, 2, 3, 4, 5, 6, 7], ANY, ANY, ANY)
+            mock_create.assert_any_call(
+                ANY, ANY, 'RM', [2, 3, 4, 5, 6, 7, 1], ANY, ANY, ANY)
+
+    def test_invalid_per_sample_length(self, cost_manager):
+        costs = [
+            np.array([1, 2, 3, 4, 5]),
+            np.array([2, 3, 4, 5, 1]),
+        ]
+        with pytest.raises(ValueError):
+            cost_manager.add(['ZN', 'B'], treatment_cost=costs,
+                             skip_cat_limit_checks=True)


### PR DESCRIPTION
EconML provides the ability to specify a cost of treatment. The recommended policy will be based not just on an expected increase in the target but also the expected decrease in the target given the number of samples being treated (and which kind of treatment/how much treatment depending on discrete/continuous features).

Before this PR only a constant cost of treatment was allowed. This PR adds the ability for users of the responsibleai package to pass treatment costs:
- per treatment feature - it might cost more to provide personalized tech support than to offer a discounted upgrade
- per sample - it might cost more to provide tech support to an advanced user compared to a standard user
- per treatment category - it might cost more to provide tech support with an in-store employee compared to a call center employee 

Additional minor updates:
- improved type hints for the CausalManager
- improved docstrings for the CausalManager