### PR TITLE
Handle scenario when model is passed as None

### DIFF
--- a/responsibleai/responsibleai/_managers/counterfactual_manager.py
+++ b/responsibleai/responsibleai/_managers/counterfactual_manager.py
@@ -108,7 +108,7 @@ class CounterfactualManager(BaseManager):
         if self._model is None:
             raise UserConfigValidationException(
                 'Model is required for counterfactual example generation and '
-                'explanations')
+                'feature importances')
 
         if new_counterfactual_config.features_to_vary != 'all' and \
                 not set(new_counterfactual_config.features_to_vary).issubset(

--- a/responsibleai/responsibleai/_managers/counterfactual_manager.py
+++ b/responsibleai/responsibleai/_managers/counterfactual_manager.py
@@ -105,6 +105,11 @@ class CounterfactualManager(BaseManager):
         return dice_explainer
 
     def _add_counterfactual_config(self, new_counterfactual_config):
+        if self._model is None:
+            raise UserConfigValidationException(
+                'Model is required for counterfactual example generation and '
+                'explanations')
+
         if new_counterfactual_config.features_to_vary != 'all' and \
                 not set(new_counterfactual_config.features_to_vary).issubset(
                     set(self._train.columns)):

--- a/responsibleai/responsibleai/_managers/error_analysis_manager.py
+++ b/responsibleai/responsibleai/_managers/error_analysis_manager.py
@@ -5,6 +5,8 @@
 
 from pathlib import Path
 import json
+
+from responsibleai.exceptions import UserConfigValidationException
 from responsibleai._internal.constants import (
     ManagerNames, ListProperties, ErrorAnalysisManagerKeys as Keys)
 from responsibleai._managers.base_manager import BaseManager
@@ -188,6 +190,10 @@ class ErrorAnalysisManager(BaseManager):
             matrix filter.
         :type filter_features: list
         """
+        if self._analyzer.model is None:
+            raise UserConfigValidationException(
+                'Model is required for error analysis')
+
         ea_config = ErrorAnalysisConfig(
             max_depth=max_depth,
             num_leaves=num_leaves,

--- a/responsibleai/responsibleai/_managers/explainer_manager.py
+++ b/responsibleai/responsibleai/_managers/explainer_manager.py
@@ -8,6 +8,7 @@ import json
 import numpy as np
 from scipy.sparse import issparse
 from pathlib import Path
+
 from interpret_community.mimic.mimic_explainer import MimicExplainer
 from interpret_community.mimic.models.lightgbm_model import (
     LGBMExplainableModel)
@@ -16,6 +17,8 @@ from interpret_community.mimic.models.linear_model import (
 from interpret_community.common.constants import ModelTask
 from interpret_community.explanation.explanation import (
     save_explanation, load_explanation, FeatureImportanceExplanation)
+
+from responsibleai.exceptions import UserConfigValidationException
 from responsibleai._internal.constants import (
     ManagerNames, Metadata, ListProperties, ExplanationKeys,
     ExplainerManagerKeys as Keys)
@@ -100,6 +103,10 @@ class ExplainerManager(BaseManager):
 
     def add(self):
         """Add an explainer to be computed later."""
+        if self._model is None:
+            raise UserConfigValidationException(
+                'Model is required for model explanations')
+
         if self._is_added:
             warnings.warn(("Ignoring.  Explanation has already been added, "
                            "currently limited to one explainer type."),

--- a/responsibleai/responsibleai/modelanalysis/model_analysis.py
+++ b/responsibleai/responsibleai/modelanalysis/model_analysis.py
@@ -6,9 +6,10 @@
 import json
 import numpy as np
 import pandas as pd
-import pickle
-
 from pathlib import Path
+import pickle
+import warnings
+
 
 from responsibleai._input_processing import _convert_to_list
 from responsibleai._interfaces import ModelAnalysisData, Dataset
@@ -190,6 +191,12 @@ class ModelAnalysis(object):
                 'Unsupported task type. Should be one of {0} or {1}'.format(
                     ModelTask.CLASSIFICATION, ModelTask.REGRESSION)
             )
+
+        if model is None:
+            warnings.warn(
+                'INVALID-MODEL-WARNING: No valid model is supplied. '
+                'The explanations, error analysis and counterfactuals '
+                'may not work')
 
         if serializer is not None:
             if not hasattr(serializer, 'save'):
@@ -488,12 +495,13 @@ class ModelAnalysis(object):
             with open(top_dir / _SERIALIZER, 'wb') as file:
                 pickle.dump(self._serializer, file)
         else:
-            has_setstate = hasattr(self.model, '__setstate__')
-            has_getstate = hasattr(self.model, '__getstate__')
-            if not (has_setstate and has_getstate):
-                raise ValueError(
-                    "Model must be picklable or a custom serializer must"
-                    " be specified")
+            if self.model is not None:
+                has_setstate = hasattr(self.model, '__setstate__')
+                has_getstate = hasattr(self.model, '__getstate__')
+                if not (has_setstate and has_getstate):
+                    raise ValueError(
+                        "Model must be picklable or a custom serializer must"
+                        " be specified")
             with open(top_dir / _MODEL_PKL, 'wb') as file:
                 pickle.dump(self.model, file)
 

--- a/responsibleai/tests/counterfactual_manager_validator.py
+++ b/responsibleai/tests/counterfactual_manager_validator.py
@@ -24,6 +24,17 @@ def verify_counterfactual_object(counterfactual_obj, feature_importance=False):
 def validate_counterfactual(cf_analyzer,
                             desired_class=None, desired_range=None,
                             feature_importance=False):
+    if cf_analyzer.model is None:
+        with pytest.raises(UserConfigValidationException,
+                           match='Model is required for counterfactual '
+                                 'example generation and explanations'):
+            cf_analyzer.counterfactual.add(
+                total_CFs=10,
+                method='random',
+                desired_class=desired_class,
+                desired_range=desired_range,
+                feature_importance=feature_importance)
+        return
 
     # Add the first configuration
     cf_analyzer.counterfactual.add(total_CFs=10,

--- a/responsibleai/tests/counterfactual_manager_validator.py
+++ b/responsibleai/tests/counterfactual_manager_validator.py
@@ -27,7 +27,7 @@ def validate_counterfactual(cf_analyzer,
     if cf_analyzer.model is None:
         with pytest.raises(UserConfigValidationException,
                            match='Model is required for counterfactual '
-                                 'example generation and explanations'):
+                                 'example generation and feature importances'):
             cf_analyzer.counterfactual.add(
                 total_CFs=10,
                 method='random',


### PR DESCRIPTION
- Logging a warning saying explanation, error analysis and coutnerfactuals may not work as expected if no valid model is passed
- Handle model as None in each of the error analysis, coutnerfactual and explainer manager toraise excecption if user does a add() operation on either of them.
- Added relevant unit tests