### PR TITLE
fix the x and y axes on the heatmap to be consistent with generated matrix

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixAreaUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixArea/MatrixAreaUtils.ts
@@ -162,8 +162,8 @@ export function createCompositeFilterFromCells(
   const multiCellCompositeFilters: ICompositeFilter[] = [];
   let keyFeature1 = undefined;
   let keyFeature2 = undefined;
-  if (feature2IsSelected && selectedFeature1) {
-    // Vertical case, where feature 2 is selected and feature 1 is not
+  if (feature2IsSelected && !selectedFeature1) {
+    // Horizontal case, where feature 2 is selected and feature 1 is not
     keyFeature2 = getKey(selectedFeature2, features);
     category2Values = category1Values;
     cat2HasIntervals = cat1HasIntervals;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixCells/MatrixCells.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixCells/MatrixCells.tsx
@@ -44,9 +44,10 @@ export interface IMatrixCellsProps {
 export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
   public render(): React.ReactNode {
     const classNames = matrixCellsStyles();
-    const topMatrixClass = this.props.selectedFeature1
-      ? classNames.matrixRow
-      : classNames.matrixCol;
+    const topMatrixClass: string =
+      this.props.selectedFeature1 && !this.props.selectedFeature2
+        ? classNames.matrixCol
+        : classNames.matrixRow;
 
     let totalError = 0;
     let falseCount = 0;
@@ -166,7 +167,7 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
                 </TooltipHost>
               </div>
             );
-            if (!this.props.selectedFeature1) {
+            if (!this.props.selectedFeature2) {
               const categoryData = (
                 <div
                   key={`${i}_${j}category1`}
@@ -182,10 +183,7 @@ export class MatrixCells extends React.PureComponent<IMatrixCellsProps> {
                 </div>
               );
             } else if (j === 0) {
-              if (
-                !this.props.selectedFeature2 ||
-                this.props.sameFeatureSelected
-              ) {
+              if (!this.props.selectedFeature1) {
                 return [
                   <div
                     key={`${i}_${j}category1`}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFilter/MatrixFilter.tsx
@@ -95,7 +95,7 @@ export class MatrixFilter extends React.PureComponent<
             <Stack.Item key="feature1key">
               <ComboBox
                 defaultSelectedKey=""
-                label="X-Axis: Feature 1"
+                label="Y-Axis: Feature 1"
                 options={this.options}
                 dropdownMaxWidth={300}
                 useComboBoxAsMenuWidth
@@ -110,7 +110,7 @@ export class MatrixFilter extends React.PureComponent<
             <Stack.Item key="feature2key">
               <ComboBox
                 defaultSelectedKey=""
-                label="Y-Axis: Feature 2"
+                label="X-Axis: Feature 2"
                 options={this.options}
                 dropdownMaxWidth={300}
                 useComboBoxAsMenuWidth

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFooter/MatrixFooter.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/MatrixFooter/MatrixFooter.tsx
@@ -22,7 +22,7 @@ export class MatrixFooter extends React.PureComponent<IMatrixFooterProps> {
     const classNames = matrixFooterStyles();
     return (
       <div>
-        {(!this.props.selectedFeature2 || this.props.sameFeatureSelected) &&
+        {(!this.props.selectedFeature1 || this.props.sameFeatureSelected) &&
           this.props.category1Values.length > 0 && (
             <div
               key={`${this.props.matrixLength}row`}


### PR DESCRIPTION
Change the axes to be consistent in the error analysis heatmap: the y-axis dropdown only leads to a 1d vertical heatmap, and x-axis dropdown only leads to a 1d horizontal heatmap.  When both are selected, a 2d heatmap is creates with the y-axis feature on the vertical side and the x-axis feature on the horizontal side.  Note x and y axis order in dropdowns were flipped to be more consistent with matrix notation (rows, columns, where y-axis corresponds to rows and x-axis to columns)