### PR TITLE
Separate previously concatenated train/test in causal analysis

### DIFF
--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -143,17 +143,16 @@ class CausalManager(BaseManager):
                        f"got {nuisance_model}")
             raise UserConfigValidationException(message)
 
-        # Update X and y to contain both train and test
-        # This solves issues with categorical features missing some
-        # categories in the test set and causing transformers to fail
-        X = pd.concat([self._train, self._test], ignore_index=True)\
-            .drop([self._target_column], axis=1)
-        y = pd.concat([self._train, self._test], ignore_index=True)[
-            self._target_column].values.ravel()
-
         categoricals = self._categorical_features
         if categoricals is None:
             categoricals = []
+
+        X_train = self._train.drop([self._target_column], axis=1)
+        X_test = self._test.drop([self._target_column], axis=1)
+        y_train = self._train[self._target_column].values.ravel()
+
+        self._validate_train_test_categories(
+            X_train, X_test, categoricals)
 
         is_classification = self._task_type == ModelTask.CLASSIFICATION
         analysis = CausalAnalysis(
@@ -170,7 +169,7 @@ class CausalManager(BaseManager):
             verbose=verbose,
             random_state=random_state,
         )
-        self._fit_causal_analysis(analysis, X, y,
+        self._fit_causal_analysis(analysis, X_train, y_train,
                                   upper_bound_on_cat_expansion)
 
         result = CausalResult()
@@ -192,8 +191,6 @@ class CausalManager(BaseManager):
         )
 
         result.causal_analysis = analysis
-
-        X_test = self._test.drop([self._target_column], axis=1)
 
         result.global_effects = analysis.global_causal_effect(
             alpha=alpha, keep_all_levels=True)
@@ -233,6 +230,27 @@ class CausalManager(BaseManager):
             result.policies.append(policy)
         self._results.append(result)
         return result
+
+    def _validate_train_test_categories(
+        self,
+        X_train: pd.DataFrame,
+        X_test: pd.DataFrame,
+        categoricals,
+    ):
+        discovered = {}
+        for column in X_train.columns:
+            if column in categoricals:
+                train_unique = np.unique(X_train[column])
+                test_unique = np.unique(X_test[column])
+                difference = np.setdiff1d(test_unique, train_unique)
+                if difference.shape[0] != 0:
+                    discovered[column] = difference.tolist()
+        if len(discovered) > 0:
+            message = ("Causal analysis requires that every category of "
+                       "categorical features present in the test data "
+                       "be also present in the train data. "
+                       "Categories missing from train data: {}")
+            raise UserConfigValidationException(message.format(discovered))
 
     def _fit_causal_analysis(
         self,

--- a/responsibleai/tests/test_causal/test_causal_manager.py
+++ b/responsibleai/tests/test_causal/test_causal_manager.py
@@ -120,7 +120,7 @@ class TestCausalManager:
                    "Categories missing from train data: "
                    "{'state': \\['indiana'\\]}")
         with pytest.raises(UserConfigValidationException, match=message):
-            manager.add(['population'],
+            manager.add(['state'],
                         skip_cat_limit_checks=True,
                         upper_bound_on_cat_expansion=50)
 

--- a/responsibleai/tests/test_causal/test_causal_manager.py
+++ b/responsibleai/tests/test_causal/test_causal_manager.py
@@ -26,17 +26,6 @@ def boston_data():
 
 
 @pytest.fixture(scope='module')
-def adult_data():
-    X_train_df, X_test_df, y_train, y_test,\
-        _, _, target_name, _ = create_adult_income_dataset()
-    train_df = copy.deepcopy(X_train_df)
-    test_df = copy.deepcopy(X_test_df)
-    train_df[target_name] = y_train
-    test_df[target_name] = y_test
-    return train_df, test_df, X_train_df.columns, target_name
-
-
-@pytest.fixture(scope='module')
 def parks_data():
     feature_names = ['state', 'population', 'attraction', 'area']
     train_df = pd.DataFrame([


### PR DESCRIPTION
Causal analysis does not allow categories of categorical variables to be missing from the training dataset while existing in the test dataset. This was originally mitigated by merging the train and test data before fitting the causal models.

This has become a problem because it is unintuitive what train and test mean when setting up model analysis. This PR removes the merge of train and test and also adds new validation to fail fast under scenarios with missing categories.

Original merge/concat was done in this PR: https://github.com/microsoft/responsible-ai-widgets/pull/566