### PR TITLE
add min child samples parameter to error analysis

### DIFF
--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -107,23 +107,27 @@ class BaseAnalyzer(ABC):
                            filters,
                            composite_filters,
                            max_depth=None,
-                           num_leaves=None):
+                           num_leaves=None,
+                           min_child_samples=None):
         return _compute_error_tree(self,
                                    features,
                                    filters,
                                    composite_filters,
                                    max_depth=max_depth,
-                                   num_leaves=num_leaves)
+                                   num_leaves=num_leaves,
+                                   min_child_samples=min_child_samples)
 
     def create_error_report(self,
                             filter_features=None,
                             max_depth=None,
-                            num_leaves=None):
+                            num_leaves=None,
+                            min_child_samples=None):
         tree = self.compute_error_tree(self.feature_names,
                                        None,
                                        None,
                                        max_depth=max_depth,
-                                       num_leaves=num_leaves)
+                                       num_leaves=num_leaves,
+                                       min_child_samples=min_child_samples)
         matrix = None
         if filter_features is not None:
             matrix = self.compute_matrix(filter_features,

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '15'
+_patch = '16'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_surrogate_error_tree.py
+++ b/erroranalysis/tests/test_surrogate_error_tree.py
@@ -57,11 +57,13 @@ class TestSurrogateErrorTree(object):
         diff = pred_y != y_test
         max_depth = 3
         num_leaves = 31
+        min_child_samples = 20
         surrogate = create_surrogate_model(error_analyzer,
                                            X_test,
                                            diff,
                                            max_depth,
                                            num_leaves,
+                                           min_child_samples,
                                            cat_ind_reindexed)
         model_json = surrogate._Booster.dump_model()
         tree_structure = model_json["tree_info"][0]['tree_structure']
@@ -86,8 +88,22 @@ class TestSurrogateErrorTree(object):
                                 max_split_index, feature_names)
 
 
+    def test_min_child_samples(self):
+        X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
+
+        model = create_kneighbors_classifier(X_train, y_train)
+        categorical_features = []
+        min_child_samples_list = [5, 10, 20]
+        for min_child_samples in min_child_samples_list:
+            run_error_analyzer(model, X_test, y_test, feature_names,
+                               categorical_features,
+                               min_child_samples=min_child_samples)
+
+
 def run_error_analyzer(model, X_test, y_test, feature_names,
-                       categorical_features, tree_features=None):
+                       categorical_features, tree_features=None,
+                       max_depth=3, num_leaves=31,
+                       min_child_samples=20):
     error_analyzer = ModelAnalyzer(model, X_test, y_test,
                                    feature_names,
                                    categorical_features)
@@ -95,9 +111,10 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
         tree_features = feature_names
     filters = None
     composite_filters = None
-    tree = error_analyzer.compute_error_tree(tree_features,
-                                             filters,
-                                             composite_filters)
+    tree = error_analyzer.compute_error_tree(
+        tree_features, filters, composite_filters,
+        max_depth=max_depth, num_leaves=num_leaves,
+        min_child_samples=min_child_samples)
     assert tree is not None
     assert len(tree) > 0
     assert ERROR in tree[0]
@@ -106,6 +123,8 @@ def run_error_analyzer(model, X_test, y_test, feature_names,
     assert tree[0][PARENTID] is None
     assert SIZE in tree[0]
     assert tree[0][SIZE] == len(X_test)
+    for node in tree:
+        assert node[SIZE] >= min_child_samples
 
 
 def validate_traversed_tree(tree, tree_dict, max_split_index,

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -37,7 +37,8 @@ class ErrorAnalysisDashboardInput:
             model_task,
             metric,
             max_depth,
-            num_leaves):
+            num_leaves,
+            min_child_samples):
         """Initialize the ErrorAnalysis Dashboard Input.
 
         :param explanation: An object that represents an explanation.
@@ -93,6 +94,9 @@ class ErrorAnalysisDashboardInput:
         :param num_leaves: The number of leaves of the surrogate tree
             trained on errors.
         :type num_leaves: int
+        :param min_child_samples: The minimal number of data required
+            to create one leaf.
+        :type min_child_samples: int
         """
         self._model = model
         full_dataset = dataset
@@ -113,6 +117,7 @@ class ErrorAnalysisDashboardInput:
         feature_length = None
         self._max_depth = max_depth
         self._num_leaves = num_leaves
+        self._min_child_samples = min_child_samples
 
         if has_explanation:
             if classes is None:
@@ -420,7 +425,8 @@ class ErrorAnalysisDashboardInput:
             tree = self._error_analyzer.compute_error_tree(
                 features, filters, composite_filters,
                 max_depth=self._max_depth,
-                num_leaves=self._num_leaves)
+                num_leaves=self._num_leaves,
+                min_child_samples=self._min_child_samples)
             return {
                 WidgetRequestResponseConstants.DATA: tree
             }

--- a/responsibleai/responsibleai/_internal/constants.py
+++ b/responsibleai/responsibleai/_internal/constants.py
@@ -42,6 +42,7 @@ class ErrorAnalysisManagerKeys(object):
     IS_COMPUTED = 'is_computed'
     MAX_DEPTH = 'max_depth'
     NUM_LEAVES = 'num_leaves'
+    MIN_CHILD_SAMPLES = 'min_child_samples'
     FILTER_FEATURES = 'filter_features'
     REPORTS = 'reports'
 


### PR DESCRIPTION
add min child samples parameter to error analysis to control the minimal number of data points required to create one leaf in the tree view