### PR TITLE
add min child samples parameter to error analysis

### DIFF
--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -107,23 +107,27 @@ class BaseAnalyzer(ABC):
                            filters,
                            composite_filters,
                            max_depth=None,
-                           num_leaves=None):
+                           num_leaves=None,
+                           min_child_samples=None):
         return _compute_error_tree(self,
                                    features,
                                    filters,
                                    composite_filters,
                                    max_depth=max_depth,
-                                   num_leaves=num_leaves)
+                                   num_leaves=num_leaves,
+                                   min_child_samples=min_child_samples)
 
     def create_error_report(self,
                             filter_features=None,
                             max_depth=None,
-                            num_leaves=None):
+                            num_leaves=None,
+                            min_child_samples=None):
         tree = self.compute_error_tree(self.feature_names,
                                        None,
                                        None,
                                        max_depth=max_depth,
-                                       num_leaves=num_leaves)
+                                       num_leaves=num_leaves,
+                                       min_child_samples=min_child_samples)
         matrix = None
         if filter_features is not None:
             matrix = self.compute_matrix(filter_features,

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -27,6 +27,7 @@ from sklearn.metrics import (
 MODEL = 'model'
 DEFAULT_MAX_DEPTH = 3
 DEFAULT_NUM_LEAVES = 31
+DEFAULT_MIN_CHILD_SAMPLES = 20
 
 
 class TreeSide(str, Enum):
@@ -48,7 +49,8 @@ def compute_json_error_tree(analyzer,
                             filters,
                             composite_filters,
                             max_depth=DEFAULT_MAX_DEPTH,
-                            num_leaves=DEFAULT_NUM_LEAVES):
+                            num_leaves=DEFAULT_NUM_LEAVES,
+                            min_child_samples=DEFAULT_MIN_CHILD_SAMPLES):
     # Note: this is for backcompat for older versions
     # of raiwidgets pypi package
     return compute_error_tree(analyzer,
@@ -56,7 +58,8 @@ def compute_json_error_tree(analyzer,
                               filters,
                               composite_filters,
                               max_depth,
-                              num_leaves)
+                              num_leaves,
+                              min_child_samples)
 
 
 def compute_error_tree(analyzer,
@@ -64,12 +67,15 @@ def compute_error_tree(analyzer,
                        filters,
                        composite_filters,
                        max_depth=DEFAULT_MAX_DEPTH,
-                       num_leaves=DEFAULT_NUM_LEAVES):
+                       num_leaves=DEFAULT_NUM_LEAVES,
+                       min_child_samples=DEFAULT_MIN_CHILD_SAMPLES):
     # Fit a surrogate model on errors
     if max_depth is None:
         max_depth = DEFAULT_MAX_DEPTH
     if num_leaves is None:
         num_leaves = DEFAULT_NUM_LEAVES
+    if min_child_samples is None:
+        min_child_samples = DEFAULT_MIN_CHILD_SAMPLES
     is_model_analyzer = hasattr(analyzer, MODEL)
     if is_model_analyzer:
         filtered_df = filter_from_cohort(analyzer.dataset,
@@ -135,6 +141,7 @@ def compute_error_tree(analyzer,
                                        diff,
                                        max_depth,
                                        num_leaves,
+                                       min_child_samples,
                                        cat_ind_reindexed)
 
     filtered_indexed_df = pd.DataFrame(dataset_sub_features,
@@ -161,6 +168,7 @@ def create_surrogate_model(analyzer,
                            diff,
                            max_depth,
                            num_leaves,
+                           min_child_samples,
                            cat_ind_reindexed):
     """Creates and fits the surrogate lightgbm model.
 
@@ -178,6 +186,9 @@ def create_surrogate_model(analyzer,
     :param num_leaves: The number of leaves of the surrogate tree
         trained on errors.
     :type num_leaves: int
+    :param min_child_samples: The minimal number of data required to
+        create one leaf.
+    :type min_child_samples: int
     :param cat_ind_reindexed: The list of categorical feature indexes.
     :type cat_ind_reindexed: list[int]
     :return: The trained surrogate model.
@@ -186,11 +197,13 @@ def create_surrogate_model(analyzer,
     if analyzer.model_task == ModelTask.CLASSIFICATION:
         surrogate = LGBMClassifier(n_estimators=1,
                                    max_depth=max_depth,
-                                   num_leaves=num_leaves)
+                                   num_leaves=num_leaves,
+                                   min_child_samples=min_child_samples)
     else:
         surrogate = LGBMRegressor(n_estimators=1,
                                   max_depth=max_depth,
-                                  num_leaves=num_leaves)
+                                  num_leaves=num_leaves,
+                                  min_child_samples=min_child_samples)
     if cat_ind_reindexed:
         surrogate.fit(dataset_sub_features, diff,
                       categorical_feature=cat_ind_reindexed)

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '15'
+_patch = '16'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -11,6 +11,7 @@ from flask import jsonify, request
 
 DEFAULT_MAX_DEPTH = 3
 DEFAULT_NUM_LEAVES = 31
+DEFAULT_MIN_CHILD_SAMPLES = 20
 
 
 class ErrorAnalysisDashboard(Dashboard):
@@ -81,7 +82,8 @@ class ErrorAnalysisDashboard(Dashboard):
                  categorical_features=None, true_y_dataset=None,
                  pred_y=None, model_task=ModelTask.UNKNOWN,
                  metric=None, max_depth=DEFAULT_MAX_DEPTH,
-                 num_leaves=DEFAULT_NUM_LEAVES):
+                 num_leaves=DEFAULT_NUM_LEAVES,
+                 min_child_samples=DEFAULT_MIN_CHILD_SAMPLES):
         """ErrorAnalysis Dashboard Class.
 
         :param explanation: An object that represents an explanation.
@@ -141,12 +143,15 @@ class ErrorAnalysisDashboard(Dashboard):
         :param num_leaves: The number of leaves of the surrogate tree
             trained on errors.
         :type num_leaves: int
+        :param min_child_samples: The minimal number of data required
+            to create one leaf.
+        :type min_child_samples: int
         """
         self.input = ErrorAnalysisDashboardInput(
             explanation, model, dataset, true_y, classes,
             features, categorical_features,
             true_y_dataset, pred_y, model_task, metric,
-            max_depth, num_leaves)
+            max_depth, num_leaves, min_child_samples)
         super(ErrorAnalysisDashboard, self).__init__(
             dashboard_type="ErrorAnalysis",
             model_data=self.input.dashboard_input,

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -37,7 +37,8 @@ class ErrorAnalysisDashboardInput:
             model_task,
             metric,
             max_depth,
-            num_leaves):
+            num_leaves,
+            min_child_samples):
         """Initialize the ErrorAnalysis Dashboard Input.
 
         :param explanation: An object that represents an explanation.
@@ -93,6 +94,9 @@ class ErrorAnalysisDashboardInput:
         :param num_leaves: The number of leaves of the surrogate tree
             trained on errors.
         :type num_leaves: int
+        :param min_child_samples: The minimal number of data required
+            to create one leaf.
+        :type min_child_samples: int
         """
         self._model = model
         full_dataset = dataset
@@ -113,6 +117,7 @@ class ErrorAnalysisDashboardInput:
         feature_length = None
         self._max_depth = max_depth
         self._num_leaves = num_leaves
+        self._min_child_samples = min_child_samples
 
         if has_explanation:
             if classes is None:
@@ -420,7 +425,8 @@ class ErrorAnalysisDashboardInput:
             tree = self._error_analyzer.compute_error_tree(
                 features, filters, composite_filters,
                 max_depth=self._max_depth,
-                num_leaves=self._num_leaves)
+                num_leaves=self._num_leaves,
+                min_child_samples=self._min_child_samples)
             return {
                 WidgetRequestResponseConstants.DATA: tree
             }

--- a/responsibleai/responsibleai/_internal/constants.py
+++ b/responsibleai/responsibleai/_internal/constants.py
@@ -42,6 +42,7 @@ class ErrorAnalysisManagerKeys(object):
     IS_COMPUTED = 'is_computed'
     MAX_DEPTH = 'max_depth'
     NUM_LEAVES = 'num_leaves'
+    MIN_CHILD_SAMPLES = 'min_child_samples'
     FILTER_FEATURES = 'filter_features'
     REPORTS = 'reports'
 

--- a/responsibleai/responsibleai/_managers/error_analysis_manager.py
+++ b/responsibleai/responsibleai/_managers/error_analysis_manager.py
@@ -21,6 +21,7 @@ REPORTS = 'reports'
 CONFIG = 'config'
 MAX_DEPTH = Keys.MAX_DEPTH
 NUM_LEAVES = Keys.NUM_LEAVES
+MIN_CHILD_SAMPLES = Keys.MIN_CHILD_SAMPLES
 FILTER_FEATURES = Keys.FILTER_FEATURES
 IS_COMPUTED = 'is_computed'
 
@@ -51,15 +52,21 @@ def as_error_config(json_dict):
     """
     has_max_depth = MAX_DEPTH in json_dict
     has_num_leaves = NUM_LEAVES in json_dict
+    has_min_child_samples = MIN_CHILD_SAMPLES in json_dict
     has_filter_features = FILTER_FEATURES in json_dict
     has_is_computed = IS_COMPUTED in json_dict
     has_all_fields = (has_max_depth and has_num_leaves and
-                      has_filter_features and has_is_computed)
+                      has_min_child_samples and has_filter_features and
+                      has_is_computed)
     if has_all_fields:
         max_depth = json_dict[MAX_DEPTH]
         num_leaves = json_dict[NUM_LEAVES]
+        min_child_samples = json_dict[MIN_CHILD_SAMPLES]
         filter_features = json_dict[FILTER_FEATURES]
-        config = ErrorAnalysisConfig(max_depth, num_leaves, filter_features)
+        config = ErrorAnalysisConfig(max_depth,
+                                     num_leaves,
+                                     min_child_samples,
+                                     filter_features)
         config.is_computed = json_dict[IS_COMPUTED]
         return config
     else:
@@ -74,18 +81,25 @@ class ErrorAnalysisConfig(BaseConfig):
     :type max_depth: int
     :param num_leaves: The number of leaves in the tree.
     :type num_leaves: int
+    :param min_child_samples: The minimal number of data required to
+        create one leaf.
+    :type min_child_samples: int
     :param filter_features: One or two features to use for the
         matrix filter.
     :type filter_features: list
     """
 
-    def __init__(self, max_depth, num_leaves, filter_features):
+    def __init__(self, max_depth, num_leaves,
+                 min_child_samples, filter_features):
         """Defines the ErrorAnalysisConfig, specifying the parameters to run.
 
         :param max_depth: The maximum depth of the tree.
         :type max_depth: int
         :param num_leaves: The number of leaves in the tree.
         :type num_leaves: int
+        :param min_child_samples: The minimal number of data required to
+            create one leaf.
+        :type min_child_samples: int
         :param filter_features: One or two features to use for the
             matrix filter.
         :type filter_features: list
@@ -93,6 +107,7 @@ class ErrorAnalysisConfig(BaseConfig):
         super(ErrorAnalysisConfig, self).__init__()
         self.max_depth = max_depth
         self.num_leaves = num_leaves
+        self.min_child_samples = min_child_samples
         self.filter_features = filter_features
 
     def __eq__(self, other_ea_config):
@@ -104,6 +119,7 @@ class ErrorAnalysisConfig(BaseConfig):
         return (
             self.max_depth == other_ea_config.max_depth and
             self.num_leaves == other_ea_config.num_leaves and
+            self.min_child_samples == other_ea_config.min_child_samples and
             self.filter_features == other_ea_config.filter_features
         )
 
@@ -111,14 +127,15 @@ class ErrorAnalysisConfig(BaseConfig):
     def __dict__(self):
         """Returns the dictionary representation of the ErrorAnalysisConfig.
 
-        The dictionary contains the max depth, num leaves and list of
-        matrix filter features.
+        The dictionary contains the max depth, num leaves, min
+        child samples and list of matrix filter features.
 
         :return: The dictionary representation of the ErrorAnalysisConfig.
         :rtype: dict
         """
         return {'max_depth': self.max_depth,
                 'num_leaves': self.num_leaves,
+                'min_child_samples': self.min_child_samples,
                 'filter_features': self.filter_features,
                 'is_computed': self.is_computed}
 
@@ -179,13 +196,17 @@ class ErrorAnalysisManager(BaseManager):
                                        self._feature_names,
                                        self._categorical_features)
 
-    def add(self, max_depth=3, num_leaves=31, filter_features=None):
+    def add(self, max_depth=3, num_leaves=31,
+            min_child_samples=20, filter_features=None):
         """Add an error analyzer to be computed later.
 
         :param max_depth: The maximum depth of the tree.
         :type max_depth: int
         :param num_leaves: The number of leaves in the tree.
         :type num_leaves: int
+        :param min_child_samples: The minimal number of data required to
+            create one leaf.
+        :type min_child_samples: int
         :param filter_features: One or two features to use for the
             matrix filter.
         :type filter_features: list
@@ -197,6 +218,7 @@ class ErrorAnalysisManager(BaseManager):
         ea_config = ErrorAnalysisConfig(
             max_depth=max_depth,
             num_leaves=num_leaves,
+            min_child_samples=min_child_samples,
             filter_features=filter_features)
         is_duplicate = ea_config.is_duplicate(
             self._ea_config_list)
@@ -217,10 +239,12 @@ class ErrorAnalysisManager(BaseManager):
             config.is_computed = True
             max_depth = config.max_depth
             num_leaves = config.num_leaves
+            min_child_samples = config.min_child_samples
             filter_features = config.filter_features
-            report = self._analyzer.create_error_report(filter_features,
-                                                        max_depth=max_depth,
-                                                        num_leaves=num_leaves)
+            report = self._analyzer.create_error_report(
+                filter_features, max_depth=max_depth,
+                min_child_samples=min_child_samples,
+                num_leaves=num_leaves)
             self._ea_report_list.append(report)
 
     def get(self):
@@ -246,6 +270,7 @@ class ErrorAnalysisManager(BaseManager):
             report[Keys.IS_COMPUTED] = config.is_computed
             report[Keys.MAX_DEPTH] = config.max_depth
             report[Keys.NUM_LEAVES] = config.num_leaves
+            report[Keys.MIN_CHILD_SAMPLES] = config.min_child_samples
             report[Keys.FILTER_FEATURES] = config.filter_features
             reports.append(report)
         props[Keys.REPORTS] = reports
@@ -264,8 +289,10 @@ class ErrorAnalysisManager(BaseManager):
         error_analysis = ErrorAnalysisData()
         error_analysis.maxDepth = report[Keys.MAX_DEPTH]
         error_analysis.numLeaves = report[Keys.NUM_LEAVES]
+        error_analysis.minChildSamples = report[Keys.MIN_CHILD_SAMPLES]
         error_analysis.tree = self._analyzer.compute_error_tree(
-            self._feature_names, None, None)
+            self._feature_names, None, None, error_analysis.maxDepth,
+            error_analysis.numLeaves, error_analysis.minChildSamples)
         error_analysis.matrix = self._analyzer.compute_matrix(
             self._feature_names, None, None)
         return error_analysis

--- a/responsibleai/tests/error_analysis_validator.py
+++ b/responsibleai/tests/error_analysis_validator.py
@@ -13,6 +13,9 @@ SIZE = 'size'
 PARENTID = 'parentId'
 ERROR = 'error'
 ID = 'id'
+MIN_CHILD_SAMPLES = Keys.MIN_CHILD_SAMPLES
+REPORTS = Keys.REPORTS
+FILTER_FEATURES = Keys.FILTER_FEATURES
 
 
 def setup_error_analysis(model_analysis, add_ea=True, max_depth=3):
@@ -39,7 +42,7 @@ def validate_error_analysis(model_analysis, expected_reports=1):
         matrix = report.matrix
         matrix_features = report.matrix_features
         tree_features = report.tree_features
-        info_features = ea_info_list[Keys.REPORTS][idx][Keys.FILTER_FEATURES]
+        info_features = ea_info_list[REPORTS][idx][FILTER_FEATURES]
         assert matrix_features == info_features
         assert tree_features == model_analysis.error_analysis._feature_names
 
@@ -53,7 +56,8 @@ def validate_error_analysis(model_analysis, expected_reports=1):
             validate_matrix(matrix, expected_count, expected_false_count)
 
         tree = report.tree
-        validate_tree(tree, expected_count)
+        min_child_samples = ea_info_list[REPORTS][idx][MIN_CHILD_SAMPLES]
+        validate_tree(tree, expected_count, min_child_samples)
 
 
 def validate_matrix(matrix, exp_total_count, exp_total_false_count):
@@ -75,7 +79,7 @@ def validate_matrix(matrix, exp_total_count, exp_total_false_count):
     assert exp_total_false_count == total_false_count
 
 
-def validate_tree(tree, expected_count):
+def validate_tree(tree, expected_count, min_child_samples):
     assert tree is not None
     assert len(tree) > 0
     assert ERROR in tree[0]
@@ -84,3 +88,5 @@ def validate_tree(tree, expected_count):
     assert tree[0][PARENTID] is None
     assert SIZE in tree[0]
     assert tree[0][SIZE] == expected_count
+    for node in tree:
+        assert node[SIZE] >= min_child_samples


### PR DESCRIPTION
add min child samples parameter to error analysis to control the minimal number of data points required to create one leaf in the tree view