### PR TITLE
Remove Table headers arrow

### DIFF
--- a/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentList.tsx
+++ b/libs/causality/src/lib/CausalAnalysisDashboard/Controls/CausalAnalysisView/TreatmentView/TreatmentList.tsx
@@ -61,8 +61,6 @@ export class TreatmentList extends React.Component<ITreatmentListProps> {
         ariaLabel: localization.Counterfactuals.EffectOfTreatment,
         fieldName: "Effect of treatment",
         isResizable: true,
-        isSorted: true,
-        isSortedDescending: false,
         key: "Effect of treatment",
         maxWidth: 400,
         minWidth: 200,

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -39,7 +39,7 @@
       "why": "Why is it important to include confounding features?"
     },
     "TreatmentPolicy": {
-      "averageGainBinary": "Average gains of alternative policies over no {0} treatment.",
+      "averageGainBinary": "Average gains of setting the treatment {0} to its baseline value.",
       "averageGainContinuous": "Average gains of alternative policies over no modification to the current treatment level for {0} treatment.",
       "BarDescriptionBinary": "This graph shows the average gains of various treatment policies relative to the baseline of not providing the {0} treatment to anyone in your population.",
       "BarDescriptionContinuous": "This graph shows the average gains of various treatment policies relative to the baseline of not making any modifications of the current treatment values given to everyone in your population.",


### PR DESCRIPTION
Table headers should not have sort arrows when the table cannot be sorted
Minor update to the recommendation policy gain chart text (only binary feature)