### PR TITLE
add quantile binning to heatmap (erroranalysis python backend only)

### DIFF
--- a/erroranalysis/erroranalysis/_internal/constants.py
+++ b/erroranalysis/erroranalysis/_internal/constants.py
@@ -32,6 +32,12 @@ class ModelTask(str, Enum):
     Regression = 'regression'
 
 
+class MatrixParams:
+    """Provide default parameters for the matrix filter aka heatmap APIs.
+    """
+    BIN_THRESHOLD = 8
+
+
 class Metrics(str, Enum):
     """Provide the supported error analysis metrics.
 

--- a/erroranalysis/erroranalysis/_internal/error_analyzer.py
+++ b/erroranalysis/erroranalysis/_internal/error_analyzer.py
@@ -13,8 +13,10 @@ from erroranalysis._internal.matrix_filter import (
 from erroranalysis._internal.surrogate_error_tree import (
     compute_error_tree as _compute_error_tree)
 from erroranalysis._internal.error_report import ErrorReport
-from erroranalysis._internal.constants import ModelTask, Metrics
+from erroranalysis._internal.constants import ModelTask, Metrics, MatrixParams
 from erroranalysis._internal.version_checker import check_pandas_version
+
+BIN_THRESHOLD = MatrixParams.BIN_THRESHOLD
 
 
 class BaseAnalyzer(ABC):
@@ -99,8 +101,18 @@ class BaseAnalyzer(ABC):
     def metric(self):
         return self._metric
 
-    def compute_matrix(self, features, filters, composite_filters):
-        return _compute_matrix(self, features, filters, composite_filters)
+    def compute_matrix(self,
+                       features,
+                       filters,
+                       composite_filters,
+                       quantile_binning=False,
+                       num_bins=BIN_THRESHOLD):
+        return _compute_matrix(self,
+                               features,
+                               filters,
+                               composite_filters,
+                               quantile_binning=quantile_binning,
+                               num_bins=num_bins)
 
     def compute_error_tree(self,
                            features,

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '16'
+_patch = '17'
 version = '{}.{}.{}'.format(_major, _minor, _patch)


### PR DESCRIPTION
- add quantile binning option to heatmap in error analysis python backend
- add num bins parameter to allow the user to control how many bins should be used for continuous real-valued features
- add tests to validate new functionality

Note this is for python backend only.  UI frontend will be updated in future PR.