### PR TITLE
Add default adult classification notebook treatment feature

### DIFF
--- a/notebooks/model-analysis-adult-classification.ipynb
+++ b/notebooks/model-analysis-adult-classification.ipynb
@@ -83,7 +83,7 @@
     "model_analysis.explainer.add()\n",
     "model_analysis.counterfactual.add(10, desired_class='opposite')\n",
     "model_analysis.error_analysis.add()\n",
-    "model_analysis.causal.add(treatment_features=['Relationship', 'Hours per week', 'Capital Gain'])\n",
+    "model_analysis.causal.add(treatment_features=['Relationship'])\n",
     "\n",
     "# Compute insights\n",
     "model_analysis.compute()"

--- a/notebooks/model-analysis-adult-classification.ipynb
+++ b/notebooks/model-analysis-adult-classification.ipynb
@@ -83,7 +83,7 @@
     "model_analysis.explainer.add()\n",
     "model_analysis.counterfactual.add(10, desired_class='opposite')\n",
     "model_analysis.error_analysis.add()\n",
-    "model_analysis.causal.add(treatment_features=['Hours per week', 'Capital Gain'])\n",
+    "model_analysis.causal.add(treatment_features=['Relationship', 'Hours per week', 'Capital Gain'])\n",
     "\n",
     "# Compute insights\n",
     "model_analysis.compute()"

--- a/notebooks/model-analysis-adult-classification.ipynb
+++ b/notebooks/model-analysis-adult-classification.ipynb
@@ -83,7 +83,7 @@
     "model_analysis.explainer.add()\n",
     "model_analysis.counterfactual.add(10, desired_class='opposite')\n",
     "model_analysis.error_analysis.add()\n",
-    "model_analysis.causal.add(treatment_features=['Relationship'])\n",
+    "model_analysis.causal.add(treatment_features=['Relationship', 'Hours per week'])\n",
     "\n",
     "# Compute insights\n",
     "model_analysis.compute()"


### PR DESCRIPTION
The two treatment features for causal analysis currently in the adult classification notebook are not very interesting for looking at the policy tree. This PR adds another more interesting feature to the treatment features list and puts it first so it is selected by default.