### PR TITLE
Format policy tree categorical features

### DIFF
--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 class TaskType(str, Enum):
@@ -18,7 +18,7 @@ class Dataset:
     probability_y: List
     true_y: List
     class_names: List[str]
-    categorical_features: [str]
+    categorical_features: List[str]
     target_column: str
 
 
@@ -94,7 +94,8 @@ class CausalPolicyTreeLeaf:
 class CausalPolicyTreeInternal:
     leaf: False
     feature: str
-    threshold: Union[float, str]  # TODO: Categorical features
+    category: Optional[str]
+    threshold: Union[float, str]
     left: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
     right: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
 
@@ -108,7 +109,7 @@ class CausalPolicy:
 
 
 class CausalConfig:
-    treatment_features: [str]
+    treatment_features: List[str]
 
 
 class CausalData:

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -105,8 +105,8 @@ class ComparisonTypes:
 class CausalPolicyTreeInternal:
     leaf: False
     feature: str
-    comparison: str
-    value: Union[str, float, int, List[Union[str, float, int]]]
+    right_comparison: str
+    comparison_value: Union[str, float, int, List[Union[str, float, int]]]
     left: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
     right: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
 

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -95,7 +95,7 @@ class CausalPolicyTreeInternal:
     leaf: False
     feature: str
     category: Optional[str]
-    threshold: Union[float, str]
+    threshold: Optional[float]
     left: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
     right: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
 

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -91,11 +91,22 @@ class CausalPolicyTreeLeaf:
     treatment: str
 
 
+class ComparisonTypes:
+    LT = 'lt'  # less than
+    LTE = 'lte'  # less than or equal to
+    GT = 'gt'  # greater than
+    GTE = 'gte'  # greater than or equal to
+    EQ = 'eq'  # equal to
+    NE = 'ne'  # not equal to
+    IN = 'in'  # in the set
+    NIN = 'nin'  # not in the set
+
+
 class CausalPolicyTreeInternal:
     leaf: False
     feature: str
-    category: Optional[str]
-    threshold: Optional[float]
+    comparison: str
+    value: Union[str, float, int, List[Union[str, float, int]]]
     left: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
     right: Union['CausalPolicyTreeInternal', CausalPolicyTreeLeaf]
 

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Union
 
 
 class TaskType(str, Enum):

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -188,6 +188,7 @@ class CausalManager(BaseManager):
             categories=categories,
             verbose=verbose,
             random_state=random_state,
+            categorical_features=self._categorical_features,
         )
 
         result.causal_analysis = analysis

--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -23,8 +23,14 @@ from responsibleai.modelanalysis.constants import ModelTask
 class CausalManager(BaseManager):
     """Manager for causal analysis."""
 
-    def __init__(self, train, test, target_column, task_type,
-                 categorical_features):
+    def __init__(
+        self,
+        train: pd.DataFrame,
+        test: pd.DataFrame,
+        target_column: str,
+        task_type: str,
+        categorical_features: Optional[List[str]]
+    ):
         """Construct a CausalManager for generating causal analyses
            from a dataset.
         :param train: Dataset on which to compute global causal effects
@@ -44,7 +50,11 @@ class CausalManager(BaseManager):
         self._test = test
         self._target_column = target_column
         self._task_type = task_type
+
         self._categorical_features = categorical_features
+        if categorical_features is None:
+            self._categorical_features = []
+
         self._results = []
 
     def add(
@@ -143,21 +153,17 @@ class CausalManager(BaseManager):
                        f"got {nuisance_model}")
             raise UserConfigValidationException(message)
 
-        categoricals = self._categorical_features
-        if categoricals is None:
-            categoricals = []
-
         X_train = self._train.drop([self._target_column], axis=1)
         X_test = self._test.drop([self._target_column], axis=1)
         y_train = self._train[self._target_column].values.ravel()
 
         self._validate_train_test_categories(
-            X_train, X_test, categoricals)
+            X_train, X_test, self._categorical_features)
 
         is_classification = self._task_type == ModelTask.CLASSIFICATION
         analysis = CausalAnalysis(
             treatment_features,
-            categoricals,
+            self._categorical_features,
             heterogeneity_inds=heterogeneity_features,
             classification=is_classification,
             nuisance_models=nuisance_model,

--- a/responsibleai/responsibleai/_tools/causal/causal_config.py
+++ b/responsibleai/responsibleai/_tools/causal/causal_config.py
@@ -20,6 +20,7 @@ class CausalConfig:
         categories,
         verbose,
         random_state,
+        categorical_features,
     ):
         self.treatment_features = treatment_features
         self.heterogeneity_features = heterogeneity_features
@@ -35,3 +36,4 @@ class CausalConfig:
         self.categories = categories
         self.verbose = verbose
         self.random_state = random_state
+        self.categorical_features = categorical_features

--- a/responsibleai/responsibleai/_tools/causal/causal_result.py
+++ b/responsibleai/responsibleai/_tools/causal/causal_result.py
@@ -150,8 +150,8 @@ class CausalResult:
             feature, comparison, value = self._parse_comparison(
                 policy_tree, self.config.categorical_features)
             policy_tree_object.feature = feature
-            policy_tree_object.comparison = comparison
-            policy_tree_object.value = value
+            policy_tree_object.right_comparison = comparison
+            policy_tree_object.comparison_value = value
             policy_tree_object.left = self._get_policy_tree_object(
                 policy_tree[ResultAttributes.LEFT])
             policy_tree_object.right = self._get_policy_tree_object(

--- a/responsibleai/tests/causal_manager_validator.py
+++ b/responsibleai/tests/causal_manager_validator.py
@@ -210,7 +210,8 @@ def _check_policy_tree(policy_tree, config, depth=0, is_serialized=False):
         else:
             assert isinstance(policy_tree, CausalPolicyTreeInternal)
             assert isinstance(policy_tree.feature, str)
-            assert hasattr(policy_tree, 'threshold')
+            assert isinstance(policy_tree.comparison, str)
+            assert isinstance(policy_tree.value, (str, int, float))
             _check_policy_tree(policy_tree.left, config, depth=depth + 1,
                                is_serialized=is_serialized)
             _check_policy_tree(policy_tree.right, config, depth=depth + 1,

--- a/responsibleai/tests/causal_manager_validator.py
+++ b/responsibleai/tests/causal_manager_validator.py
@@ -210,8 +210,8 @@ def _check_policy_tree(policy_tree, config, depth=0, is_serialized=False):
         else:
             assert isinstance(policy_tree, CausalPolicyTreeInternal)
             assert isinstance(policy_tree.feature, str)
-            assert isinstance(policy_tree.comparison, str)
-            assert isinstance(policy_tree.value, (str, int, float))
+            assert isinstance(policy_tree.right_comparison, str)
+            assert isinstance(policy_tree.comparison_value, (str, int, float))
             _check_policy_tree(policy_tree.left, config, depth=depth + 1,
                                is_serialized=is_serialized)
             _check_policy_tree(policy_tree.right, config, depth=depth + 1,

--- a/responsibleai/tests/causal_manager_validator.py
+++ b/responsibleai/tests/causal_manager_validator.py
@@ -110,7 +110,7 @@ def _check_config(config, is_serialized=False):
         assert len(config.__dict__) == 1
         assert config.treatment_features is not None
     else:
-        assert len(config.__dict__) == 14
+        assert len(config.__dict__) == 15
 
 
 def _check_causal_analysis(causal_analysis):

--- a/responsibleai/tests/test_causal/conftest.py
+++ b/responsibleai/tests/test_causal/conftest.py
@@ -1,0 +1,121 @@
+import copy
+import pandas as pd
+import pytest
+
+from typing import Tuple
+
+from ..common_utils import create_adult_income_dataset, create_boston_data
+
+
+@pytest.fixture(scope='session')
+def adult_data():
+    X_train_df, X_test_df, y_train, y_test,\
+        _, _, target_name, _ = create_adult_income_dataset()
+    train_df = copy.deepcopy(X_train_df)
+    test_df = copy.deepcopy(X_test_df)
+    train_df[target_name] = y_train
+    test_df[target_name] = y_test
+    return train_df, test_df, target_name
+
+
+@pytest.fixture(scope='session')
+def boston_data() -> Tuple[pd.DataFrame, pd.DataFrame, str]:
+    target_feature = 'TARGET'
+    X_train, X_test, y_train, y_test, feature_names = create_boston_data()
+    train_df = pd.DataFrame(X_train, columns=feature_names)
+    train_df[target_feature] = y_train
+    test_df = pd.DataFrame(X_test, columns=feature_names)
+    test_df[target_feature] = y_test
+    return train_df, test_df, target_feature
+
+
+@pytest.fixture(scope='session')
+def boston_data_categorical(boston_data):
+    train_df, test_df, target_feature = boston_data
+    train_df = copy.deepcopy(train_df)
+    test_df = copy.deepcopy(test_df)
+
+    for df in [train_df, test_df]:
+        cat_feat = df['AGE'].copy()
+        cat_feat[cat_feat >= 90] = -1
+        cat_feat[cat_feat >= 65] = -2
+        cat_feat[cat_feat >= 40] = -3
+        cat_feat[cat_feat >= 0] = -4
+        cat_feat = cat_feat.astype(str)
+        cat_feat[cat_feat == '-1.0'] = 'oldest'
+        cat_feat[cat_feat == '-2.0'] = 'older'
+        cat_feat[cat_feat == '-3.0'] = 'newer'
+        cat_feat[cat_feat == '-4.0'] = 'newest'
+        df['AGE_CAT'] = cat_feat
+
+    for df in [train_df, test_df]:
+        cat_feat = df['RM'].copy()
+        cat_feat[cat_feat >= 5] = -1
+        cat_feat[cat_feat >= 0] = -2
+        cat_feat = cat_feat.astype(str)
+        cat_feat[cat_feat == '-1.0'] = 'large'
+        cat_feat[cat_feat == '-2.0'] = 'small'
+        df['RM_CAT'] = cat_feat
+
+    for df in [train_df, test_df]:
+        cat_feat = df['INDUS'].copy()
+        cat_feat[cat_feat >= 18] = -1
+        cat_feat[cat_feat >= 10] = -2
+        cat_feat[cat_feat >= 0] = -3
+        cat_feat = cat_feat.astype(str)
+        cat_feat[cat_feat == '-1.0'] = 'commercial'
+        cat_feat[cat_feat == '-2.0'] = 'mixed'
+        cat_feat[cat_feat == '-3.0'] = 'residential'
+        df['INDUS_CAT'] = cat_feat
+
+    for df in [train_df, test_df]:
+        cat_feat = df['CRIM'].copy()
+        cat_feat[cat_feat >= 60] = -1
+        cat_feat[cat_feat >= 40] = -2
+        cat_feat[cat_feat >= 20] = -3
+        cat_feat[cat_feat >= 0] = -4
+        cat_feat = cat_feat.astype(str)
+        cat_feat[cat_feat == '-1.0'] = 'high crime'
+        cat_feat[cat_feat == '-2.0'] = 'some crime'
+        cat_feat[cat_feat == '-3.0'] = 'low cr'
+        cat_feat[cat_feat == '-4.0'] = 'no crime'
+        df['CRIM_CAT'] = cat_feat
+
+    return train_df, test_df, target_feature
+
+
+@pytest.fixture(scope='session')
+def parks_data() -> Tuple[pd.DataFrame, pd.DataFrame, str]:
+    feature_names = ['state', 'population', 'attraction', 'area']
+    train_df = pd.DataFrame([
+        ['massachusetts', 3129, 'trees', 11],
+        ['utah', 41891, 'rocks', 51],
+        ['california', 193912, 'trees', 62],
+        ['california', 123901, 'trees', 25],
+        ['utah', 39012, 'rocks', 34],
+        ['colorado', 30102, 'rocks', 40],
+        ['massachusetts', 4222, 'trees', 15],
+        ['colorado', 20342, 'rocks', 42],
+        ['arizona', 3201, 'rocks', 90],
+        ['massachusetts', 3129, 'trees', 11],
+        ['utah', 41891, 'rocks', 51],
+        ['california', 193912, 'trees', 62],
+        ['california', 123901, 'trees', 25],
+        ['utah', 39012, 'rocks', 34],
+        ['colorado', 30102, 'rocks', 40],
+        ['massachusetts', 4222, 'trees', 15],
+        ['colorado', 20342, 'rocks', 42],
+        ['arizona', 3201, 'rocks', 90],
+    ], columns=feature_names)
+
+    test_df = pd.DataFrame([
+        ['california', 323412, 'trees', 102],
+        ['utah', 5103, 'rocks', 23],
+        ['colorado', 4312, 'rocks', 19],
+        ['california', 203912, 'trees', 202],
+        ['utah', 5102, 'rocks', 21],
+        ['colorado', 8120, 'rocks', 31],
+    ], columns=feature_names)
+
+    target_feature = 'area'
+    return train_df, test_df, target_feature

--- a/responsibleai/tests/test_causal/conftest.py
+++ b/responsibleai/tests/test_causal/conftest.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
 import copy
 import numpy as np
 import pandas as pd

--- a/responsibleai/tests/test_causal/test_causal_manager.py
+++ b/responsibleai/tests/test_causal/test_causal_manager.py
@@ -178,5 +178,5 @@ class TestCausalDashboardData:
             tree = policy['policy_tree']
             assert not tree['leaf']
             assert tree['feature'] in categoricals
-            assert tree['comparison'] == 'eq'
-            assert tree['value'] == 'no crime'
+            assert tree['right_comparison'] == 'eq'
+            assert tree['comparison_value'] == 'no crime'

--- a/responsibleai/tests/test_causal/test_causal_manager.py
+++ b/responsibleai/tests/test_causal/test_causal_manager.py
@@ -157,18 +157,26 @@ class TestCausalDashboardData:
     def test_categorical_policy(self, boston_data_categorical):
         train_df, test_df, target_feature = boston_data_categorical
         categoricals = train_df.select_dtypes(include=[object]).columns
+
+        # Just use categoricals to force categorical policy tree
         new_features = list(categoricals) + [target_feature]
         train_df = train_df[new_features]
         test_df = test_df[new_features]
 
+        # Sample data for easier debug
         test_df = test_df[:10]
+
         manager = CausalManager(train_df, test_df, target_feature,
                                 ModelTask.REGRESSION, categoricals)
 
         result = manager.add(['AGE_CAT', 'INDUS_CAT'])
         dashboard_data = result._get_dashboard_data()
-        for policy in dashboard_data['policies']:
+
+        policies = dashboard_data['policies']
+        assert len(policies) > 0
+        for policy in policies:
             tree = policy['policy_tree']
             assert not tree['leaf']
             assert tree['feature'] in categoricals
             assert tree['category'] is not None
+            assert tree['threshold'] is None

--- a/responsibleai/tests/test_causal/test_causal_manager.py
+++ b/responsibleai/tests/test_causal/test_causal_manager.py
@@ -169,7 +169,7 @@ class TestCausalDashboardData:
         manager = CausalManager(train_df, test_df, target_feature,
                                 ModelTask.REGRESSION, categoricals)
 
-        result = manager.add(['AGE_CAT', 'INDUS_CAT'])
+        result = manager.add(['AGE_CAT', 'INDUS_CAT'], random_state=42)
         dashboard_data = result._get_dashboard_data()
 
         policies = dashboard_data['policies']
@@ -178,5 +178,5 @@ class TestCausalDashboardData:
             tree = policy['policy_tree']
             assert not tree['leaf']
             assert tree['feature'] in categoricals
-            assert tree['category'] is not None
-            assert tree['threshold'] is None
+            assert tree['comparison'] == 'eq'
+            assert tree['value'] == 'no crime'

--- a/responsibleai/tests/test_causal/test_causal_result.py
+++ b/responsibleai/tests/test_causal/test_causal_result.py
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+import numpy as np
+
+from responsibleai._tools.causal.causal_result import CausalResult
+
+
+class TestCausalResultParseCategorial:
+    def test_basic(self):
+        policy_tree = {
+            "leaf": False,
+            "feature": "Fruit_apple",
+            "threshold": 0.5,
+            "left": {"leaf": True, "n_samples": 8, "treatment": "decrease"},
+            "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
+        }
+        categoricals = np.array(['Fruit', 'Vegetable'])
+        feature, category = CausalResult._parse_feature_category(
+            policy_tree, categoricals)
+        assert feature == 'Fruit'
+        assert category == 'apple'
+
+    def test_selection_not_greedy(self):
+        policy_tree = {
+            "leaf": False,
+            "feature": "a_b_0",
+            "threshold": 0.5,
+            "left": {"leaf": True, "n_samples": 8, "treatment": "decrease"},
+            "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
+        }
+        categoricals = np.array(['a', 'a_b'])
+        feature, category = CausalResult._parse_feature_category(
+            policy_tree, categoricals)
+        # If greedy we would extract
+        # feature="a" and category="b_0", which is wrong
+        assert feature == 'a_b'
+        assert category == '0'
+
+    def test_failed_parse(self):
+        policy_tree = {
+            "leaf": False,
+            "feature": "Fruit_apple",
+            "threshold": 0.5,
+            "left": {"leaf": True, "n_samples": 8, "treatment": "decrease"},
+            "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
+        }
+        categoricals = np.array(['Vegetable', 'Grain'])
+        feature, category = CausalResult._parse_feature_category(
+            policy_tree, categoricals)
+        assert feature == 'Fruit_apple'
+        assert category is None
+
+    def test_empty_category(self):
+        policy_tree = {
+            "leaf": False,
+            "feature": "Fruit_",
+            "threshold": 0.5,
+            "left": {"leaf": True, "n_samples": 8, "treatment": "decrease"},
+            "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
+        }
+        categoricals = np.array(['Fruit'])
+        feature, category = CausalResult._parse_feature_category(
+            policy_tree, categoricals)
+        assert feature == 'Fruit_'
+        assert category is None

--- a/responsibleai/tests/test_causal/test_causal_result.py
+++ b/responsibleai/tests/test_causal/test_causal_result.py
@@ -15,10 +15,11 @@ class TestCausalResultParseCategorial:
             "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
         }
         categoricals = np.array(['Fruit', 'Vegetable'])
-        feature, category = CausalResult._parse_feature_category(
+        feature, category, threshold = CausalResult._parse_feature_category(
             policy_tree, categoricals)
         assert feature == 'Fruit'
         assert category == 'apple'
+        assert threshold is None
 
     def test_selection_not_greedy(self):
         policy_tree = {
@@ -29,12 +30,13 @@ class TestCausalResultParseCategorial:
             "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
         }
         categoricals = np.array(['a', 'a_b'])
-        feature, category = CausalResult._parse_feature_category(
+        feature, category, threshold = CausalResult._parse_feature_category(
             policy_tree, categoricals)
         # If greedy we would extract
         # feature="a" and category="b_0", which is wrong
         assert feature == 'a_b'
         assert category == '0'
+        assert threshold is None
 
     def test_failed_parse(self):
         policy_tree = {
@@ -45,10 +47,11 @@ class TestCausalResultParseCategorial:
             "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
         }
         categoricals = np.array(['Vegetable', 'Grain'])
-        feature, category = CausalResult._parse_feature_category(
+        feature, category, threshold = CausalResult._parse_feature_category(
             policy_tree, categoricals)
         assert feature == 'Fruit_apple'
         assert category is None
+        assert threshold == 0.5
 
     def test_empty_category(self):
         policy_tree = {
@@ -59,7 +62,8 @@ class TestCausalResultParseCategorial:
             "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
         }
         categoricals = np.array(['Fruit'])
-        feature, category = CausalResult._parse_feature_category(
+        feature, category, threshold = CausalResult._parse_feature_category(
             policy_tree, categoricals)
         assert feature == 'Fruit_'
         assert category is None
+        assert threshold == 0.5

--- a/responsibleai/tests/test_causal/test_causal_result.py
+++ b/responsibleai/tests/test_causal/test_causal_result.py
@@ -15,11 +15,11 @@ class TestCausalResultParseCategorial:
             "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
         }
         categoricals = np.array(['Fruit', 'Vegetable'])
-        feature, category, threshold = CausalResult._parse_feature_category(
+        feature, comparison, value = CausalResult._parse_comparison(
             policy_tree, categoricals)
         assert feature == 'Fruit'
-        assert category == 'apple'
-        assert threshold is None
+        assert comparison == 'eq'
+        assert value == 'apple'
 
     def test_selection_not_greedy(self):
         policy_tree = {
@@ -30,13 +30,13 @@ class TestCausalResultParseCategorial:
             "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
         }
         categoricals = np.array(['a', 'a_b'])
-        feature, category, threshold = CausalResult._parse_feature_category(
+        feature, comparison, value = CausalResult._parse_comparison(
             policy_tree, categoricals)
         # If greedy we would extract
         # feature="a" and category="b_0", which is wrong
         assert feature == 'a_b'
-        assert category == '0'
-        assert threshold is None
+        assert comparison == 'eq'
+        assert value == '0'
 
     def test_failed_parse(self):
         policy_tree = {
@@ -47,11 +47,11 @@ class TestCausalResultParseCategorial:
             "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
         }
         categoricals = np.array(['Vegetable', 'Grain'])
-        feature, category, threshold = CausalResult._parse_feature_category(
+        feature, comparison, value = CausalResult._parse_comparison(
             policy_tree, categoricals)
         assert feature == 'Fruit_apple'
-        assert category is None
-        assert threshold == 0.5
+        assert comparison == 'gt'
+        assert value == 0.5
 
     def test_empty_category(self):
         policy_tree = {
@@ -62,8 +62,8 @@ class TestCausalResultParseCategorial:
             "right": {"leaf": True, "n_samples": 6, "treatment": "increase"},
         }
         categoricals = np.array(['Fruit'])
-        feature, category, threshold = CausalResult._parse_feature_category(
+        feature, comparison, value = CausalResult._parse_comparison(
             policy_tree, categoricals)
         assert feature == 'Fruit_'
-        assert category is None
-        assert threshold == 0.5
+        assert comparison == 'gt'
+        assert value == 0.5


### PR DESCRIPTION
The causal policy tree works for both continuous and categorical features. However categorical features are always represented by one-hot features. For example, `Fruit_apple < 0.5` would be equivalent to `Fruit != apple`.

This PR formats the categorical tree splits so that they can be displayed by the UI with `==` and `!=` rather than `<` and `>`

Main algorithm for formatting is in `responsibleai/responsibleai/_tools/causal/causal_result.py`

The comparisons used are based on common comparison abbreviations. One example of their use is in MongoDB query comparisons: https://docs.mongodb.com/manual/reference/operator/query-comparison/