### PR TITLE
Add dropdown to dataset explorer by default (previously removed)

### DIFF
--- a/libs/dataset-explorer/src/lib/DatasetExplorerTab.tsx
+++ b/libs/dataset-explorer/src/lib/DatasetExplorerTab.tsx
@@ -32,9 +32,7 @@ import { datasetExplorerTabStyles } from "./DatasetExplorerTab.styles";
 import { generatePlotlyProps } from "./generatePlotlyProps";
 import { SidePanel } from "./SidePanel";
 
-export interface IDatasetExplorerTabProps {
-  showCohortSelection: boolean;
-}
+export interface IDatasetExplorerTabProps {}
 
 export interface IDatasetExplorerTabState {
   xDialogOpen: boolean;
@@ -66,35 +64,12 @@ export class DatasetExplorerTab extends React.Component<
   }
 
   public componentDidMount(): void {
-    let initialCohortIndex: number;
-    if (this.props.showCohortSelection) {
-      initialCohortIndex = 0;
-    } else {
-      initialCohortIndex = this.context.errorCohorts.findIndex(
-        (errorCohort) =>
-          errorCohort.cohort.name ===
-          this.context.selectedErrorCohort.cohort.name
-      );
-    }
+    const initialCohortIndex = 0;
 
     this.setState({
       chartProps: this.generateDefaultChartAxes(),
       selectedCohortIndex: initialCohortIndex
     });
-  }
-
-  public componentDidUpdate(): void {
-    if (this.props.showCohortSelection) {
-      return;
-    }
-
-    const selectedCohortIndex = this.context.errorCohorts.findIndex(
-      (errorCohort) =>
-        errorCohort.cohort.name === this.context.selectedErrorCohort.cohort.name
-    );
-    if (selectedCohortIndex !== this.state.selectedCohortIndex) {
-      this.setState({ selectedCohortIndex });
-    }
   }
 
   public render(): React.ReactNode {
@@ -148,27 +123,19 @@ export class DatasetExplorerTab extends React.Component<
             {localization.Interpret.DatasetExplorer.collapsedHelperText}
           </ExpandableText>
         </div>
-        {
-          // show cohort selection only in dashboards without global cohort selection mechanism
-          this.props.showCohortSelection && (
-            <div className={classNames.cohortPickerWrapper}>
-              <Text
-                variant="mediumPlus"
-                className={classNames.cohortPickerLabel}
-              >
-                {localization.Interpret.ModelPerformance.cohortPickerLabel}
-              </Text>
-              {cohortOptions && (
-                <Dropdown
-                  styles={{ dropdown: { width: 150 } }}
-                  options={cohortOptions}
-                  selectedKey={this.state.selectedCohortIndex}
-                  onChange={this.setSelectedCohort}
-                />
-              )}
-            </div>
-          )
-        }
+        <div className={classNames.cohortPickerWrapper}>
+          <Text variant="mediumPlus" className={classNames.cohortPickerLabel}>
+            {localization.Interpret.ModelPerformance.cohortPickerLabel}
+          </Text>
+          {cohortOptions && (
+            <Dropdown
+              styles={{ dropdown: { width: 150 } }}
+              options={cohortOptions}
+              selectedKey={this.state.selectedCohortIndex}
+              onChange={this.setSelectedCohort}
+            />
+          )}
+        </div>
         <div className={classNames.mainArea} id={this.chartAndConfigsId}>
           <div className={classNames.chartWithAxes}>
             {this.state.yDialogOpen && (

--- a/libs/dataset-explorer/src/lib/DatasetExplorerTab.tsx
+++ b/libs/dataset-explorer/src/lib/DatasetExplorerTab.tsx
@@ -32,7 +32,7 @@ import { datasetExplorerTabStyles } from "./DatasetExplorerTab.styles";
 import { generatePlotlyProps } from "./generatePlotlyProps";
 import { SidePanel } from "./SidePanel";
 
-export interface IDatasetExplorerTabProps {}
+export class IDatasetExplorerTabProps {}
 
 export interface IDatasetExplorerTabState {
   xDialogOpen: boolean;

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -541,9 +541,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                       ))}
                     </Pivot>
                     {this.state.activeGlobalTab ===
-                      GlobalTabKeys.DataExplorerTab && (
-                      <DatasetExplorerTab showCohortSelection />
-                    )}
+                      GlobalTabKeys.DataExplorerTab && <DatasetExplorerTab />}
                     {this.state.activeGlobalTab ===
                       GlobalTabKeys.GlobalExplanationTab && (
                       <GlobalExplanationTab

--- a/libs/interpret/src/lib/MLIDashboard/NewExplanationDashboard.tsx
+++ b/libs/interpret/src/lib/MLIDashboard/NewExplanationDashboard.tsx
@@ -171,9 +171,7 @@ export class NewExplanationDashboard extends React.PureComponent<
                   {this.state.activeGlobalTab ===
                     GlobalTabKeys.ModelPerformance && <ModelPerformanceTab />}
                   {this.state.activeGlobalTab ===
-                    GlobalTabKeys.DataExploration && (
-                    <DatasetExplorerTab showCohortSelection />
-                  )}
+                    GlobalTabKeys.DataExploration && <DatasetExplorerTab />}
                   {this.state.activeGlobalTab ===
                     GlobalTabKeys.ExplanationTab && (
                     <GlobalExplanationTab

--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/ModelAssessmentDashboard.tsx
@@ -228,7 +228,7 @@ export class ModelAssessmentDashboard extends CohortBasedComponent<
                             }
                           </Text>
                         </div>
-                        <DatasetExplorerTab showCohortSelection={false} />
+                        <DatasetExplorerTab />
                       </>
                     )}
                     {t.key === GlobalTabKeys.FeatureImportancesTab &&


### PR DESCRIPTION
This dropdown was previously removed for the model assessment dashboard, but is now added back. The custom code to decide whether or not to add the dropdown is therefore obsolete and removed in this PR.
 
Signed-off-by: Roman Lutz <rolutz@microsoft.com>