### PR TITLE
release rai-core-flask 0.2.4

### DIFF
--- a/wrapped-flask/setup.py
+++ b/wrapped-flask/setup.py
@@ -6,7 +6,7 @@ import setuptools
 
 # The version must be incremented every time we push an update to pypi (but
 # not before)
-VERSION = "0.2.3"
+VERSION = "0.2.4"
 
 # supply contents of our README file as our package's long description
 with open("README.md", "r") as fh:


### PR DESCRIPTION
- suppress distracting logging from flask when running widgets (#828)