### PR TITLE
fix node errors on 16.9 build until they are resolved

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -9,7 +9,7 @@ env:
   blob_container_for_js: latest
   blob_container_for_raiwidget: raiwidgets
   blob_path_for_pull_request: ${{ github.event.pull_request.head.repo.full_name }}/${{ github.head_ref }}
-  node-version: 16.x
+  node-version: 16.8
   widgetDirectory: raiwidgets
   raiDirectory: responsibleai
   dashboardDirectory: dashboard

--- a/.github/workflows/CI-python.yml
+++ b/.github/workflows/CI-python.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   ci-python:
     env:
-      node-version: 16.x
+      node-version: 16.8
     strategy:
       matrix:
         packageDirectory:

--- a/.github/workflows/CI-typescript.yml
+++ b/.github/workflows/CI-typescript.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.8]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
related:
https://github.com/nodejs/node/issues/40030
https://github.com/GoogleChrome/lighthouse/pull/13012
https://bugs.chromium.org/p/v8/issues/detail?id=12188

seems to have started a couple hours ago, pinning to 16.8 for now which seems to be the recommended workaround