### PR TITLE
[test only] fix seed on learner to prevent flaky test

### DIFF
--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -60,7 +60,7 @@ def create_kneighbors_classifier(X, y):
 
 
 def create_sklearn_logistic_regressor(X, y, pipeline=False):
-    lin = LogisticRegression(solver='liblinear')
+    lin = LogisticRegression(solver='liblinear', random_state=777)
     if pipeline:
         lin = Pipeline([('lin', lin)])
     model = lin.fit(X, y)
@@ -133,7 +133,7 @@ def create_cancer_data():
 
 
 def create_binary_classification_dataset():
-    X, y = make_classification()
+    X, y = make_classification(random_state=777)
 
     # Split data into train and test
     X_train, X_test, y_train, y_test = train_test_split(X,

--- a/responsibleai/tests/common_utils.py
+++ b/responsibleai/tests/common_utils.py
@@ -48,7 +48,7 @@ def create_sklearn_svm_classifier(X, y, probability=True):
 
 
 def create_sklearn_logistic_regressor(X, y, pipeline=False):
-    lin = LogisticRegression(solver='liblinear')
+    lin = LogisticRegression(solver='liblinear', random_state=777)
     if pipeline:
         lin = Pipeline([('lin', lin)])
     model = lin.fit(X, y)
@@ -91,7 +91,7 @@ def create_cancer_data():
 
 
 def create_binary_classification_dataset():
-    X, y = make_classification()
+    X, y = make_classification(random_state=777)
 
     # Split data into train and test
     X_train, X_test, y_train, y_test = train_test_split(X,


### PR DESCRIPTION
fix seed on learner to prevent flaky test, as this test was sometimes failing:

test_matrix_filter_binary_classification 

From scikit-learn doc:

**random_stateint, RandomState instance, default=None**

    Used when solver == ‘sag’, ‘saga’ or ‘liblinear’ to shuffle the data. See Glossary for details.


