### PR TITLE
remove deprecated babelconfig option

### DIFF
--- a/workspace.json
+++ b/workspace.json
@@ -47,7 +47,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -116,7 +115,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -185,7 +183,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -381,7 +378,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -450,7 +446,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -519,7 +514,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -588,7 +582,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -653,7 +646,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -722,7 +714,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {
@@ -791,7 +782,6 @@
               "react-dom",
               "uuid"
             ],
-            "babelConfig": "@nrwl/react/plugins/bundle-babel",
             "rollupConfig": "./rollup.config.js",
             "assets": [
               {


### PR DESCRIPTION
Removing deprecated babelconfig option from workspace.json.
This seemed to give a build error this morning on github CI for another PR but I am only seeing warnings when I build locally.  Regardless it at least fixes the local warnings.  Everything seems to be working fine with this option removed so I think it's a safe change to make.

Warnings I see locally:
![image](https://user-images.githubusercontent.com/24683184/134194964-53ac9a39-0e42-48de-a4bf-6b86a1b755e2.png)
