### PR TITLE
fix displayed error rate on all data cohort in cohort list and error in heatmap for classification case

### DIFF
--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -407,7 +407,8 @@ def matrix_2d(categories1, categories2, matrix_counts,
             if metric == Metrics.ERROR_RATE:
                 matrix_row.append({
                     FALSE_COUNT: false_count,
-                    COUNT: total_count
+                    COUNT: total_count,
+                    METRIC_NAME: metric_to_display_name[metric]
                 })
             elif is_precision or is_recall:
                 matrix_row.append({
@@ -463,7 +464,8 @@ def matrix_1d(categories, values_err, counts, counts_err,
                 false_count = int(counts_err[index_err])
             matrix_row.append({
                 FALSE_COUNT: false_count,
-                COUNT: int(counts[col_idx])
+                COUNT: int(counts[col_idx]),
+                METRIC_NAME: metric_to_display_name[metric]
             })
         elif is_precision or is_recall:
             tp_sum = []

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '19'
+_patch = '20'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixArea.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixArea.tsx
@@ -220,17 +220,16 @@ export class MatrixArea extends React.PureComponent<
             maxMetricValue = Math.max(maxMetricValue, metricValue);
           }
         }
-        if (value.metricName !== undefined) {
-          if (
-            value.metricName === Metrics.PrecisionScore ||
+        if (
+          value.metricName !== undefined &&
+          (value.metricName === Metrics.PrecisionScore ||
             value.metricName === Metrics.RecallScore ||
             value.metricName === Metrics.MicroPrecisionScore ||
             value.metricName === Metrics.MacroPrecisionScore ||
             value.metricName === Metrics.MicroRecallScore ||
-            value.metricName === Metrics.MacroRecallScore
-          ) {
-            isErrorMetric = false;
-          }
+            value.metricName === Metrics.MacroRecallScore)
+        ) {
+          isErrorMetric = false;
         }
       });
     });

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixAreaUtils.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixArea/MatrixAreaUtils.ts
@@ -71,9 +71,12 @@ export function createCohortStatsFromSelectedCells(
   selectedCells: boolean[],
   jsonMatrix: IErrorAnalysisMatrix
 ): MetricCohortStats {
-  const metricName = jsonMatrix.matrix[0][0].metricName;
+  let metricName = jsonMatrix.matrix[0][0].metricName;
   let statsAggregator: BaseStatsAggregator;
-  if (metricName === Metrics.ErrorRate) {
+  // Note for older versions of error analysis package metricName is
+  // undefined for ErrorRate
+  if (metricName === Metrics.ErrorRate || metricName === undefined) {
+    metricName = Metrics.ErrorRate;
     statsAggregator = new ErrorRateStatsAggregator(metricName);
   } else if (
     metricName === Metrics.MeanSquaredError ||

--- a/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard_input.py
@@ -308,7 +308,7 @@ class ErrorAnalysisDashboardInput:
                     true_y = np.array(true_y)
                 diff = predicted_y != true_y
                 error = sum(diff)
-                metric_value = error / total
+                metric_value = (error / total) * 100
         metric_name = metric_to_display_name[metric]
         root_stats = {
             ExplanationDashboardInterface.ROOT_METRIC_NAME: metric_name,

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -6,6 +6,6 @@ jinja2==2.11.3
 ipython==7.16.1
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
-erroranalysis>=0.1.17
+erroranalysis>=0.1.20
 fairlearn>=0.7.0
 ipykernel<6.0

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,6 +1,6 @@
 dice-ml>=0.7.1,<0.8
 econml~=0.12.0
-erroranalysis>=0.1.17
+erroranalysis>=0.1.20
 interpret-community>=0.18.1
 lightgbm>=2.0.11
 numpy>=1.17.2


### PR DESCRIPTION
Fixes issue: https://github.com/microsoft/responsible-ai-widgets/issues/766
where error rate is sometimes not multiplied by 100.  Specifically I saw this in:
- cohort list for All Data cohort
- in heatmap legend before selecting a cell

Also while testing I discovered another issue related to a PR that was just recently merged where heatmap doesn't work in classification case for ErrorRate metric because the metricName is undefined.  I fixed this both in the frontend so it will work with older versions of erroranalysis package that don't send the metricName and also added the metricName to be sent from the python backend to prevent this issue from happening again.
