### PR TITLE
decrease the lower bound on first category for quantile binning

### DIFF
--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '21'
+_patch = '22'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/common_utils.py
+++ b/erroranalysis/tests/common_utils.py
@@ -166,14 +166,14 @@ def create_simple_titanic_data():
     return X_train, X_test, y_train, y_test, num_features, cat_features
 
 
-def create_boston_data():
+def create_boston_data(test_size=0.2):
     # Import Boston housing dataset
     boston = load_boston()
     # Split data into train and test
-    X_train, X_test, y_train, y_validation = train_test_split(
+    X_train, X_test, y_train, y_test = train_test_split(
         boston.data, boston.target,
-        test_size=0.2, random_state=7)
-    return X_train, X_test, y_train, y_validation, boston.feature_names
+        test_size=test_size, random_state=7)
+    return X_train, X_test, y_train, y_test, boston.feature_names
 
 
 def create_models_classification(X_train, y_train):

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -251,6 +251,19 @@ class TestMatrixFilter(object):
                                      y_test, feature_names,
                                      model_task, filters=filters)
 
+    def test_matrix_filter_boston_quantile_binning(self):
+        # Test quantile binning on CRIM feature in boston dataset,
+        # which errored out due to first category not fitting into bins
+        X_train, X_test, y_train, y_test, feature_names = \
+            create_boston_data(test_size=0.5)
+
+        model_task = ModelTask.REGRESSION
+        matrix_features = ['CRIM']
+        run_error_analyzer_on_models(X_train, y_train, X_test,
+                                     y_test, feature_names, model_task,
+                                     matrix_features=matrix_features,
+                                     quantile_binning=True)
+
 
 def run_error_analyzer_on_models(X_train,
                                  y_train,

--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -90,6 +90,7 @@ class ErrorAnalysisDashboard(Dashboard):
 
     # Run simple view of error analysis with just predictions and
     # true labels
+
     >>> predictions = model.predict(X_test)
     >>> from raiwidgets import ErrorAnalysisDashboard
     >>> ErrorAnalysisDashboard(dataset=X_test, true_y=y_test,
@@ -98,6 +99,7 @@ class ErrorAnalysisDashboard(Dashboard):
     :Example:
 
     # Run error analysis with a model and a computed explanation
+
     >>> from raiwidgets import ErrorAnalysisDashboard
     >>> ErrorAnalysisDashboard(global_explanation, model,
     ...                        dataset=X_test, true_y=y_test)
@@ -106,6 +108,7 @@ class ErrorAnalysisDashboard(Dashboard):
 
     # Run error analysis on large data and a downsampled dataset
     # for the UI
+
     >>> from raiwidgets import ErrorAnalysisDashboard
     >>> ErrorAnalysisDashboard(sample_dataset=X_test_sample,
     ...                        dataset=X_test,


### PR DESCRIPTION
For certain cases when using quantile binning this error would be thrown:

```IndexError: arrays used as indices must be of integer or boolean type```

Which would happen on assignment in the line:

```val_err = cut_err.cat.categories[val_err]```

The problem was that val_err had a much larger size than categories due to a lot of NaNs, and these NaNs came from quantile binning when the lowest value was not included in the index.  Unfortunately with IntervalIndex all Intervals have to have same inclusive [] brackets or exclusive () braces on the same side, which seems like a real limitation as mentioned on this issue:

https://github.com/pandas-dev/pandas/issues/23164

Here in this issue include_lowest subtracts a small delta from pd.cut, and in fact in testing it seems even if it's not set pd.cut makes the lower bound lower, but this is not happening with pd.qcut.  This PR henceforth decreases the lowest interval in the interval index by some tolerance (set to 1 percent in this PR) so that the lower bound can be included.

If this is still a problem in the future another suggestion might be to make the lower/upper bounds infs to include all points, see stackoverflow comment:
https://stackoverflow.com/questions/50145702/pandas-cut-doesnt-bin-zero-values

But I don't think this looks as nice to users and is a bit more confusing to see when the matrix values are binned.