### PR TITLE
fix failing test in build

### DIFF
--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -111,7 +111,8 @@ class TestMatrixFilter(object):
             (UserWarning, err_capg),
             (UserWarning, err_capl)
         }
-        assert warns == expected
+        for expected_warning in expected:
+            assert expected_warning in warns
 
     def test_matrix_filter_iris_num_bins(self):
         X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()


### PR DESCRIPTION
seeing a random warning pop up from scikit-learn which wasn't there before (maybe a new version of scikit-learn in the builds?), changing test to be less flaky by not having an exact match on warning but just check that the expected warnings are there