### PR TITLE
Raise exception when users configures less than required counterfactuals

### DIFF
--- a/responsibleai/responsibleai/_managers/counterfactual_manager.py
+++ b/responsibleai/responsibleai/_managers/counterfactual_manager.py
@@ -159,6 +159,14 @@ class CounterfactualManager(BaseManager):
                     'The desired_range should not be None'
                     ' for regression scenarios.')
 
+        if new_counterfactual_config.feature_importance and\
+                new_counterfactual_config.total_CFs < 10:
+            raise UserConfigValidationException(
+                "A total_CFs value of at least 10 is required to "
+                "use counterfactual feature importances. "
+                "Either increase total_CFs to at least 10 or "
+                "set feature_importance to False.")
+
         is_duplicate = new_counterfactual_config.is_duplicate(
             self._counterfactual_config_list)
 

--- a/responsibleai/tests/counterfactual_manager_validator.py
+++ b/responsibleai/tests/counterfactual_manager_validator.py
@@ -5,9 +5,6 @@ import pytest
 from responsibleai.exceptions import (
     DuplicateManagerConfigException, UserConfigValidationException
 )
-from dice_ml.utils.exception import (
-    UserConfigValidationException as DiceException
-)
 
 
 def verify_counterfactual_object(counterfactual_obj, feature_importance=False):
@@ -72,7 +69,7 @@ def validate_counterfactual(cf_analyzer,
                                  feature_importance=feature_importance)
 
     # Add a bad configuration
-    with pytest.raises(DiceException):
+    with pytest.raises(UserConfigValidationException):
         cf_analyzer.counterfactual.add(total_CFs=-20,
                                        method='random',
                                        desired_class=desired_class,
@@ -82,4 +79,3 @@ def validate_counterfactual(cf_analyzer,
     assert cf_analyzer.counterfactual.get() is not None
     assert isinstance(cf_analyzer.counterfactual.get(), list)
     assert len(cf_analyzer.counterfactual.get()) == 2
-    assert len(cf_analyzer.counterfactual.get(failed_to_compute=True)) == 1

--- a/responsibleai/tests/counterfactual_manager_validator.py
+++ b/responsibleai/tests/counterfactual_manager_validator.py
@@ -5,6 +5,9 @@ import pytest
 from responsibleai.exceptions import (
     DuplicateManagerConfigException, UserConfigValidationException
 )
+from dice_ml.utils.exception import (
+    UserConfigValidationException as DiceException
+)
 
 
 def verify_counterfactual_object(counterfactual_obj, feature_importance=False):
@@ -69,13 +72,23 @@ def validate_counterfactual(cf_analyzer,
                                  feature_importance=feature_importance)
 
     # Add a bad configuration
-    with pytest.raises(UserConfigValidationException):
-        cf_analyzer.counterfactual.add(total_CFs=-20,
-                                       method='random',
-                                       desired_class=desired_class,
-                                       desired_range=desired_range,
-                                       feature_importance=feature_importance)
-        cf_analyzer.counterfactual.compute()
+    if feature_importance:
+        with pytest.raises(UserConfigValidationException):
+            cf_analyzer.counterfactual.add(
+                total_CFs=2,
+                method='random',
+                desired_class=desired_class,
+                desired_range=desired_range,
+                feature_importance=feature_importance)
+    else:
+        with pytest.raises(DiceException):
+            cf_analyzer.counterfactual.add(
+                total_CFs=-2,
+                method='random',
+                desired_class=desired_class,
+                desired_range=desired_range,
+                feature_importance=feature_importance)
+            cf_analyzer.counterfactual.compute()
     assert cf_analyzer.counterfactual.get() is not None
     assert isinstance(cf_analyzer.counterfactual.get(), list)
     assert len(cf_analyzer.counterfactual.get()) == 2

--- a/responsibleai/tests/test_model_analysis_validations.py
+++ b/responsibleai/tests/test_model_analysis_validations.py
@@ -450,6 +450,31 @@ class TestCounterfactualUserConfigValidations:
                 method='random',
                 desired_class='opposite')
 
+    def test_feature_importance_with_less_counterfactuals(self):
+        X_train, X_test, y_train, y_test, feature_names, classes = \
+            create_iris_data()
+        model = create_lightgbm_classifier(X_train, y_train)
+        X_train['target'] = y_train
+        X_test['target'] = y_test
+
+        model_analysis = ModelAnalysis(
+            model=model,
+            train=X_train,
+            test=X_test,
+            target_column='target',
+            task_type='classification')
+
+        with pytest.raises(
+                UserConfigValidationException,
+                match="A total_CFs value of at least 10 is required to "
+                      "use counterfactual feature importances. "
+                      "Either increase total_CFs to at least 10 or "
+                      "set feature_importance to False."):
+            model_analysis.counterfactual.add(
+                total_CFs=5,
+                method='random',
+                desired_class=2)
+
     def test_eval_data_having_new_categories(self):
         train_data = pd.DataFrame(
             data=[[1, 2, 0],


### PR DESCRIPTION
dice-ml needs at least ten counterfactuals to be computed to compute feature importance. Hence, the exception.