### PR TITLE
fix handling of numeric features names in pandas for error analysis tree view

### DIFF
--- a/erroranalysis/README.md
+++ b/erroranalysis/README.md
@@ -1,6 +1,6 @@
 # Error Analysis SDK for Python
 
-### This package has been tested with Python 3.5, 3.6 and 3.7
+### This package has been tested with Python 3.6, 3.7 and 3.8
 
 The error analysis sdk enables users to get a deeper understanding of machine learning model errors. When evaluating a machine learning model, aggregate accuracy is not sufficient and single-score evaluation may hide important conditions of inaccuracies. Use Error Analysis to identify cohorts with higher error rates and diagnose the root causes behind these errors.
 

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '20'
+_patch = '21'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/raiwidgets/requirements.txt
+++ b/raiwidgets/requirements.txt
@@ -6,6 +6,6 @@ jinja2==2.11.3
 ipython==7.16.1
 scikit-learn>=0.22.1
 lightgbm>=2.0.11
-erroranalysis>=0.1.20
+erroranalysis>=0.1.21
 fairlearn>=0.7.0
 ipykernel<6.0

--- a/raiwidgets/tests/test_error_analysis_dashboard.py
+++ b/raiwidgets/tests/test_error_analysis_dashboard.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 from sklearn.datasets import make_classification, load_iris
 from raiwidgets import ErrorAnalysisDashboard
+from raiwidgets.explanation_constants import WidgetRequestResponseConstants
 from interpret_community.common.constants import ModelTask
 from interpret.ext.blackbox import MimicExplainer
 from interpret.ext.glassbox import LGBMExplainableModel
@@ -17,25 +18,6 @@ class TestErrorAnalysisDashboard:
     def test_error_analysis_adult_census(self):
         X, y = shap.datasets.adult()
         y = [1 if r else 0 for r in y]
-
-        X, y = sklearn.utils.resample(
-            X, y, n_samples=1000, random_state=7, stratify=y)
-
-        X_train, X_test, y_train, y_test = train_test_split(
-            X, y, test_size=0.2, random_state=7, stratify=y)
-
-        knn = sklearn.neighbors.KNeighborsClassifier()
-        knn.fit(X_train, y_train)
-
-        model_task = ModelTask.Classification
-        explainer = MimicExplainer(knn,
-                                   X_train,
-                                   LGBMExplainableModel,
-                                   augment_data=True,
-                                   max_num_of_augmentations=10,
-                                   model_task=model_task)
-        global_explanation = explainer.explain_global(X_test)
-
         categorical_features = ['Workclass',
                                 'Education-Num',
                                 'Marital Status',
@@ -44,11 +26,7 @@ class TestErrorAnalysisDashboard:
                                 'Race',
                                 'Sex',
                                 'Country']
-        ErrorAnalysisDashboard(global_explanation,
-                               knn,
-                               dataset=X_test,
-                               true_y=y_test,
-                               categorical_features=categorical_features)
+        run_error_analysis_adult_census(X, y, categorical_features)
 
     def test_error_analysis_many_rows(self):
         X, y = make_classification(n_samples=110000)
@@ -126,6 +104,76 @@ class TestErrorAnalysisDashboard:
                                knn,
                                dataset=X_test,
                                true_y=y_test)
+
+    def test_error_analysis_iris_numeric_feature_names(self):
+        # e2e test of error analysis with numeric feature names
+        X_train, X_test, y_train, y_test, _, _ = create_iris_data()
+        knn = sklearn.neighbors.KNeighborsClassifier()
+        knn.fit(X_train, y_train)
+
+        model_task = ModelTask.Classification
+        explainer = MimicExplainer(knn,
+                                   X_train,
+                                   LGBMExplainableModel,
+                                   model_task=model_task)
+        global_explanation = explainer.explain_global(X_test)
+
+        dashboard = ErrorAnalysisDashboard(global_explanation,
+                                           knn,
+                                           dataset=X_test,
+                                           true_y=y_test)
+        result = dashboard.input.debug_ml(global_explanation.features, [], [])
+        assert WidgetRequestResponseConstants.ERROR not in result
+        matrix_features = global_explanation.features[0:1]
+        result = dashboard.input.matrix(matrix_features, [], [], True, 8)
+        assert WidgetRequestResponseConstants.ERROR not in result
+
+    def test_error_analysis_adult_census_numeric_feature_names(self):
+        X, y = shap.datasets.adult()
+        categorical_features = ['Workclass',
+                                'Education-Num',
+                                'Marital Status',
+                                'Occupation',
+                                'Relationship',
+                                'Race',
+                                'Sex',
+                                'Country']
+        columns = X.columns.tolist()
+        cat_idxs = [columns.index(feat) for feat in categorical_features]
+        # Convert to numpy to remove features names
+        X = X.values
+        y = [1 if r else 0 for r in y]
+
+        run_error_analysis_adult_census(X, y, cat_idxs)
+
+
+def run_error_analysis_adult_census(X, y, categorical_features):
+    X, y = sklearn.utils.resample(
+        X, y, n_samples=1000, random_state=7, stratify=y)
+
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=7, stratify=y)
+
+    knn = sklearn.neighbors.KNeighborsClassifier()
+    knn.fit(X_train, y_train)
+
+    model_task = ModelTask.Classification
+    explainer = MimicExplainer(knn,
+                               X_train,
+                               LGBMExplainableModel,
+                               augment_data=True,
+                               max_num_of_augmentations=10,
+                               model_task=model_task)
+    global_explanation = explainer.explain_global(X_test)
+
+    dashboard = ErrorAnalysisDashboard(
+        global_explanation, knn, dataset=X_test,
+        true_y=y_test, categorical_features=categorical_features)
+    result = dashboard.input.debug_ml(global_explanation.features, [], [])
+    assert WidgetRequestResponseConstants.ERROR not in result
+    matrix_features = global_explanation.features[0:1]
+    result = dashboard.input.matrix(matrix_features, [], [], True, 8)
+    assert WidgetRequestResponseConstants.ERROR not in result
 
 
 def create_iris_data():

--- a/responsibleai/requirements.txt
+++ b/responsibleai/requirements.txt
@@ -1,6 +1,6 @@
 dice-ml>=0.7.2,<0.8
 econml~=0.12.0
-erroranalysis>=0.1.20
+erroranalysis>=0.1.21
 interpret-community>=0.18.1
 lightgbm>=2.0.11
 numpy>=1.17.2


### PR DESCRIPTION
A customer who did not pass their feature names to the explainer and generated an explanation without features hit an exception in error analysis dashboard due to numeric feature names.  This PR allows error analysis dashboard to work with numeric feature names and adds an end to end test.