### PR TITLE
add tree view parameters to error analysis dashboard

### DIFF
--- a/apps/dashboard/src/error-analysis/App.tsx
+++ b/apps/dashboard/src/error-analysis/App.tsx
@@ -81,6 +81,11 @@ export class App extends React.Component<IAppProps> {
       if (this.props.version === 1) {
         dashboardProp = {
           ...dataset,
+          errorAnalysisData: {
+            maxDepth: 3,
+            minChildSamples: 21,
+            numLeaves: 31
+          },
           explanationMethod: "mimic",
           features: featureNames,
           locale: this.props.language,
@@ -103,6 +108,11 @@ export class App extends React.Component<IAppProps> {
       } else if (this.props.version === 3) {
         dashboardProp = {
           ...dataset,
+          errorAnalysisData: {
+            maxDepth: 3,
+            minChildSamples: 21,
+            numLeaves: 31
+          },
           explanationMethod: "mimic",
           features: featureNames,
           locale: this.props.language,
@@ -115,14 +125,23 @@ export class App extends React.Component<IAppProps> {
           theme: this.props.theme
         };
       } else {
+        const staticTree = getJsonTreeBoston(featureNames);
+        const staticMatrix = getJsonMatrix();
         dashboardProp = {
           ...dataset,
+          errorAnalysisData: {
+            matrix: staticMatrix.data,
+            matrix_features: staticMatrix.features,
+            maxDepth: 3,
+            minChildSamples: 21,
+            numLeaves: 31,
+            tree: staticTree.data,
+            tree_features: staticTree.features
+          },
           explanationMethod: "mimic",
           features: featureNames,
           locale: this.props.language,
           localUrl: "https://www.bing.com/",
-          staticDebugML: getJsonTreeBoston(featureNames),
-          staticMatrix: getJsonMatrix(),
           stringParams: { contextualHelp: this.messages },
           theme: this.props.theme
         };
@@ -160,6 +179,11 @@ export class App extends React.Component<IAppProps> {
             localUrl={""}
             locale={undefined}
             features={this.props.dataset.featureNames}
+            errorAnalysisData={{
+              maxDepth: 3,
+              minChildSamples: 21,
+              numLeaves: 31
+            }}
           />
         );
       } else if (this.props.version === 3) {
@@ -185,9 +209,18 @@ export class App extends React.Component<IAppProps> {
             localUrl={""}
             locale={undefined}
             features={this.props.dataset.featureNames}
+            errorAnalysisData={{
+              maxDepth: 3,
+              minChildSamples: 21,
+              numLeaves: 31
+            }}
           />
         );
       }
+      const staticTree = getJsonTreeAdultCensusIncome(
+        this.props.dataset.featureNames
+      );
+      const staticMatrix = getJsonMatrix();
       return (
         <ErrorAnalysisDashboard
           modelInformation={{ modelClass: "blackbox" }}
@@ -203,13 +236,18 @@ export class App extends React.Component<IAppProps> {
           precomputedExplanations={{
             localFeatureImportance: this.props.dataset.localExplanations
           }}
-          staticDebugML={getJsonTreeAdultCensusIncome(
-            this.props.dataset.featureNames
-          )}
-          staticMatrix={getJsonMatrix()}
           localUrl={""}
           locale={undefined}
           features={this.props.dataset.featureNames}
+          errorAnalysisData={{
+            matrix: staticMatrix.data,
+            matrix_features: staticMatrix.features,
+            maxDepth: 3,
+            minChildSamples: 21,
+            numLeaves: 31,
+            tree: staticTree.data,
+            tree_features: staticTree.features
+          }}
         />
       );
     }
@@ -226,6 +264,7 @@ export class App extends React.Component<IAppProps> {
       }
       dashboardProp = {
         ...dataset,
+        errorAnalysisData: { maxDepth: 3, minChildSamples: 21, numLeaves: 31 },
         explanationMethod: "mimic",
         features: dataset.dataSummary.featureNames
           ? dataset.dataSummary.featureNames
@@ -251,6 +290,7 @@ export class App extends React.Component<IAppProps> {
       const dataset = this.props.dataset as IExplanationDashboardData;
       dashboardProp = {
         ...dataset,
+        errorAnalysisData: { maxDepth: 3, minChildSamples: 21, numLeaves: 31 },
         explanationMethod: "mimic",
         features: dataset.dataSummary.featureNames
           ? dataset.dataSummary.featureNames
@@ -275,14 +315,23 @@ export class App extends React.Component<IAppProps> {
       const featureNames = dataset.dataSummary.featureNames
         ? dataset.dataSummary.featureNames
         : [];
+      const staticTree = requestFunction(featureNames);
+      const staticMatrix = getJsonMatrix();
       dashboardProp = {
         ...(this.props.dataset as IExplanationDashboardData),
+        errorAnalysisData: {
+          matrix: staticMatrix.data,
+          matrix_features: staticMatrix.features,
+          maxDepth: 3,
+          minChildSamples: 21,
+          numLeaves: 31,
+          tree: staticTree.data,
+          tree_features: staticTree.features
+        },
         explanationMethod: "mimic",
         features: featureNames,
         locale: this.props.language,
         localUrl: "https://www.bing.com/",
-        staticDebugML: requestFunction(featureNames),
-        staticMatrix: getJsonMatrix(),
         stringParams: { contextualHelp: this.messages },
         theme: this.props.theme
       };

--- a/apps/dashboard/src/model-assessment/__mock_data__/adultCensus.ts
+++ b/apps/dashboard/src/model-assessment/__mock_data__/adultCensus.ts
@@ -13573,5 +13573,6 @@ export const adultCensusCausalAnalysisData: ICausalAnalysisData = {
 };
 export const adultCensusCausalErrorAnalysisData: IErrorAnalysisData = {
   maxDepth: 3,
+  minChildSamples: 21,
   numLeaves: 11
 };

--- a/apps/dashboard/src/model-assessment/__mock_data__/bostonData.ts
+++ b/apps/dashboard/src/model-assessment/__mock_data__/bostonData.ts
@@ -3442,5 +3442,6 @@ export const bostonCensusCausalAnalysisData: ICausalAnalysisData = {
 };
 export const bostonErrorAnalysisData: IErrorAnalysisData = {
   maxDepth: 3,
+  minChildSamples: 21,
   numLeaves: 11
 };

--- a/apps/widget/src/app/ErrorAnalysis.tsx
+++ b/apps/widget/src/app/ErrorAnalysis.tsx
@@ -59,6 +59,7 @@ export class ErrorAnalysis extends React.Component {
         locale={config.locale}
         features={modelData.featureNames}
         rootStats={modelData.rootStats}
+        errorAnalysisData={modelData.errorAnalysisData}
       />
     );
   }

--- a/libs/core-ui/src/lib/Interfaces/IErrorAnalysisData.ts
+++ b/libs/core-ui/src/lib/Interfaces/IErrorAnalysisData.ts
@@ -8,6 +8,7 @@ export interface IErrorAnalysisData {
   matrix_features?: string[];
   maxDepth: number;
   numLeaves: number;
+  minChildSamples: number;
 }
 // Represents the data retrieved from the backend
 export interface IErrorAnalysisTreeNode {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InfoCallout/InfoCallout.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InfoCallout/InfoCallout.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+import { FabricStyles } from "@responsible-ai/core-ui";
 import { Callout, IconButton } from "office-ui-fabric-react";
 import React from "react";
 
@@ -50,6 +51,7 @@ export class InfoCallout extends React.Component<
             setInitialFocus
             onDismiss={this.onDismiss}
             role="alertdialog"
+            styles={{ container: FabricStyles.calloutContainer }}
           >
             <div className={classNames.calloutInfo}>
               <span>{this.props.infoText}</span>

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewParameters/TreeViewParameters.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewParameters/TreeViewParameters.styles.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  IStyle,
+  mergeStyleSets,
+  IProcessedStyleSet
+} from "office-ui-fabric-react";
+
+export interface ITreeViewParametersStyles {
+  sliderLabelStyle: IStyle;
+  sliderStackStyle: IStyle;
+  infoCallout: IStyle;
+}
+
+export const treeViewParametersStyles: () => IProcessedStyleSet<ITreeViewParametersStyles> =
+  () => {
+    return mergeStyleSets<ITreeViewParametersStyles>({
+      infoCallout: {
+        zIndex: 1
+      },
+      sliderLabelStyle: {
+        padding: 0
+      },
+      sliderStackStyle: {
+        minWidth: 200
+      }
+    });
+  };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewParameters/TreeViewParameters.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewParameters/TreeViewParameters.tsx
@@ -1,0 +1,123 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { localization } from "@responsible-ai/localization";
+import { Slider, Label } from "office-ui-fabric-react";
+import React from "react";
+
+import { InfoCallout } from "../InfoCallout/InfoCallout";
+
+import { treeViewParametersStyles } from "./TreeViewParameters.styles";
+
+export interface ITreeViewParametersProps {
+  updateMaxDepth: (maxDepth: number) => void;
+  updateNumLeaves: (numLeaves: number) => void;
+  updateMinChildSamples: (minChildSamples: number) => void;
+  maxDepth: number;
+  numLeaves: number;
+  minChildSamples: number;
+  isEnabled: boolean;
+}
+
+export interface ITreeViewParametersState {
+  maxDepth: number;
+  numLeaves: number;
+  minChildSamples: number;
+}
+
+export class TreeViewParameters extends React.Component<
+  ITreeViewParametersProps,
+  ITreeViewParametersState
+> {
+  private readonly _maximumDepthIconId = "maximumDepthIconId";
+  private readonly _numLeavesIconId = "numLeavesIconId";
+  private readonly _minChildSamplesIconId = "minChildSamplesIconId";
+
+  public render(): React.ReactNode {
+    const classNames = treeViewParametersStyles();
+    return (
+      <div>
+        <Label className={classNames.sliderLabelStyle}>
+          {localization.ErrorAnalysis.TreeViewParameters.maximumDepth}
+          <InfoCallout
+            iconId={this._maximumDepthIconId}
+            infoText={
+              localization.ErrorAnalysis.TreeViewParameters.maximumDepthInfoText
+            }
+            title={
+              localization.ErrorAnalysis.TreeViewParameters.maximumDepthTitle
+            }
+          />
+        </Label>
+        <Slider
+          max={10}
+          min={1}
+          value={this.props.maxDepth}
+          showValue
+          onChanged={this.onMaxDepthSliderChanged}
+          disabled={!this.props.isEnabled}
+        />
+        <Label className={classNames.sliderLabelStyle}>
+          {localization.ErrorAnalysis.TreeViewParameters.numLeaves}
+          <InfoCallout
+            iconId={this._numLeavesIconId}
+            infoText={
+              localization.ErrorAnalysis.TreeViewParameters.numLeavesInfoText
+            }
+            title={localization.ErrorAnalysis.TreeViewParameters.numLeavesTitle}
+          />
+        </Label>
+        <Slider
+          max={100}
+          min={1}
+          value={this.props.numLeaves}
+          showValue
+          onChanged={this.onNumLeavesSliderChanged}
+          disabled={!this.props.isEnabled}
+        />
+        <Label className={classNames.sliderLabelStyle}>
+          {localization.ErrorAnalysis.TreeViewParameters.minDataInLeaf}
+          <InfoCallout
+            iconId={this._minChildSamplesIconId}
+            infoText={
+              localization.ErrorAnalysis.TreeViewParameters
+                .minDataInLeafInfoText
+            }
+            title={
+              localization.ErrorAnalysis.TreeViewParameters.minDataInLeafTitle
+            }
+          />
+        </Label>
+        <Slider
+          max={100}
+          min={1}
+          value={this.props.minChildSamples}
+          showValue
+          onChanged={this.onMinChildSamplesSliderChanged}
+          disabled={!this.props.isEnabled}
+        />
+      </div>
+    );
+  }
+
+  private onMaxDepthSliderChanged = (
+    _: MouseEvent | TouchEvent | KeyboardEvent,
+    value: number
+  ): void => {
+    this.props.updateMaxDepth(value);
+  };
+
+  private onNumLeavesSliderChanged = (
+    _: MouseEvent | TouchEvent | KeyboardEvent,
+    value: number
+  ): void => {
+    this.props.updateNumLeaves(value);
+  };
+
+  private onMinChildSamplesSliderChanged = (
+    _: MouseEvent | TouchEvent | KeyboardEvent,
+    value: number
+  ): void => {
+    this.props.updateMinChildSamples(value);
+  };
+}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/TreeViewRenderer/TreeViewRenderer.tsx
@@ -119,7 +119,11 @@ export class TreeViewRenderer extends React.PureComponent<
     if (
       this.props.selectedFeatures !== prevProps.selectedFeatures ||
       this.props.baseCohort !== prevProps.baseCohort ||
-      this.props.state !== prevProps.state
+      this.props.state !== prevProps.state ||
+      this.context.errorAnalysisData!.maxDepth !== this.state.maxDepth ||
+      this.context.errorAnalysisData!.numLeaves !== this.state.numLeaves ||
+      this.context.errorAnalysisData!.minChildSamples !==
+        this.state.minChildSamples
     ) {
       this.fetchTreeNodes();
     }
@@ -406,6 +410,10 @@ export class TreeViewRenderer extends React.PureComponent<
         return state;
       }
 
+      const maxDepth = this.context.errorAnalysisData!.maxDepth;
+      const numLeaves = this.context.errorAnalysisData!.numLeaves;
+      const minChildSamples = this.context.errorAnalysisData!.minChildSamples;
+
       const rootSize = requestTreeNodes[0].size;
       const rootErrorSize = requestTreeNodes[0].error;
       const isErrorRate = requestTreeNodes[0].metricName === Metrics.ErrorRate;
@@ -493,7 +501,10 @@ export class TreeViewRenderer extends React.PureComponent<
 
       return {
         isErrorMetric,
+        maxDepth,
+        minChildSamples,
         nodeDetail,
+        numLeaves,
         request: state.request,
         root,
         rootErrorSize,
@@ -598,7 +609,10 @@ export class TreeViewRenderer extends React.PureComponent<
       const nodeDetail = this.getNodeDetail(node);
       return {
         isErrorMetric: state.isErrorMetric,
+        maxDepth: state.maxDepth,
+        minChildSamples: state.minChildSamples,
         nodeDetail,
+        numLeaves: state.numLeaves,
         request: state.request,
         root: state.root,
         rootErrorSize: state.rootErrorSize,
@@ -650,7 +664,8 @@ export class TreeViewRenderer extends React.PureComponent<
           filtersRelabeled,
           compositeFiltersRelabeled,
           this.context.errorAnalysisData?.maxDepth,
-          this.context.errorAnalysisData?.numLeaves
+          this.context.errorAnalysisData?.numLeaves,
+          this.context.errorAnalysisData?.minChildSamples
         ],
         new AbortController().signal
       )

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -279,7 +279,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
     });
     let selectedFeatures = props.features;
     if (props.requestDebugML === undefined) {
-      selectedFeatures = props.staticDebugML.features;
+      selectedFeatures = props.errorAnalysisData.tree_features!;
     }
     return {
       activeGlobalTab: GlobalTabKeys.DataExplorerTab,
@@ -339,6 +339,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
           dataset: {} as IDataset,
           deleteCohort: () => undefined,
           editCohort: () => undefined,
+          errorAnalysisData: this.props.errorAnalysisData,
           errorCohorts: this.state.cohorts,
           jointDataset: this.state.jointDataset,
           modelExplanationData: {
@@ -520,7 +521,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
                     baseCohort={this.state.baseCohort}
                     tree={
                       this.props.requestDebugML === undefined
-                        ? this.props.staticDebugML.data
+                        ? this.props.errorAnalysisData.tree
                         : undefined
                     }
                     treeViewState={this.state.treeViewState}

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardProps.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardProps.ts
@@ -5,7 +5,8 @@ import {
   IOfficeFabricProps,
   IExplanationDashboardData,
   ITelemetryMessage,
-  IErrorAnalysisMatrix
+  IErrorAnalysisMatrix,
+  IErrorAnalysisData
 } from "@responsible-ai/core-ui";
 
 import { IStringsParam } from "./IStringsParam";
@@ -57,8 +58,7 @@ export interface IErrorAnalysisDashboardProps
     abortSignal: AbortSignal
   ) => Promise<any[]>;
   localUrl: string;
-  staticDebugML?: any;
-  staticMatrix?: any;
   rootStats?: IRootStats;
   telemetryHook?: (message: ITelemetryMessage) => void;
+  errorAnalysisData: IErrorAnalysisData;
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/TreeViewState.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/TreeViewState.ts
@@ -36,6 +36,9 @@ export interface ITreeViewRendererState {
   rootErrorSize: any;
   rootLocalError: any;
   isErrorMetric: boolean;
+  maxDepth: number;
+  numLeaves: number;
+  minChildSamples: number;
 }
 
 // Represents IRequestNode with augmented calculations
@@ -63,6 +66,8 @@ export interface INodeState {
 export function createInitialTreeViewState(): ITreeViewRendererState {
   return {
     isErrorMetric: true,
+    maxDepth: 4,
+    minChildSamples: 20,
     nodeDetail: {
       errorColor: "#eaeaea",
       maskDown: {
@@ -72,6 +77,7 @@ export function createInitialTreeViewState(): ITreeViewRendererState {
         transform: "translate(0px, 13px)"
       }
     },
+    numLeaves: 31,
     request: undefined,
     root: undefined,
     rootErrorSize: 0,

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -151,6 +151,17 @@
       "features": "Features",
       "importances": "Importances"
     },
+    "TreeViewParameters": {
+      "maximumDepth": "Maximum depth",
+      "maximumDepthInfoText": "The maximum depth of the surrogate tree trained on errors",
+      "maximumDepthTitle": "Additional information on maximum depth",
+      "numLeaves": "Number of leaves",
+      "numLeavesInfoText": "The number of leaves of the surrogate tree trained on errors",
+      "numLeavesTitle": "Additional information on number of leaves",
+      "minDataInLeaf": "Minimum number of samples in one leaf",
+      "minDataInLeafInfoText": "The minimum number of data required to create one leaf",
+      "minDataInLeafTitle": "Additional information on minimum number of samples in one leaf"
+    },
     "FilterTooltip": {
       "correctNum": "Correct (#): ",
       "countNum": "Count (#): ",

--- a/raiwidgets/raiwidgets/error_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/error_analysis_dashboard.py
@@ -153,7 +153,7 @@ class ErrorAnalysisDashboard(Dashboard):
 
         def tree():
             data = request.get_json(force=True)
-            return jsonify(self.input.debug_ml(data[0], data[1], data[2]))
+            return jsonify(self.input.debug_ml(data))
 
         self.add_url_rule(tree, '/tree', methods=["POST"])
 

--- a/raiwidgets/raiwidgets/explanation_constants.py
+++ b/raiwidgets/raiwidgets/explanation_constants.py
@@ -11,6 +11,7 @@ class ExplanationDashboardInterface(object):
     CLASS_NAMES = "classNames"
     CUSTOM_VISUALS = "customVis"
     EBM_EXPLANATION = "ebmGlobalExplanation"
+    ERROR_ANALYSIS_DATA = 'errorAnalysisData'
     EXPLANATION_METHOD = 'explanation_method'
     FEATURE_NAMES = "featureNames"
     GLOBAL_EXPLANATION = "globalExplanation"

--- a/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
+++ b/raiwidgets/raiwidgets/model_analysis_dashboard_input.py
@@ -55,10 +55,15 @@ class ModelAnalysisDashboardInput:
 
     def debug_ml(self, data):
         try:
-            features, filters, composite_filters, max_depth, num_leaves = data
+            features = data[0]
+            filters = data[1]
+            composite_filters = data[2]
+            max_depth = data[3]
+            num_leaves = data[4]
+            min_child_samples = data[5]
             tree = self._error_analyzer.compute_error_tree(
                 features, filters, composite_filters,
-                max_depth, num_leaves)
+                max_depth, num_leaves, min_child_samples)
             return {
                 WidgetRequestResponseConstants.data: tree
             }

--- a/raiwidgets/tests/test_error_analysis_dashboard.py
+++ b/raiwidgets/tests/test_error_analysis_dashboard.py
@@ -12,6 +12,8 @@ from raiwidgets.explanation_constants import WidgetRequestResponseConstants
 from interpret_community.common.constants import ModelTask
 from interpret.ext.blackbox import MimicExplainer
 from interpret.ext.glassbox import LGBMExplainableModel
+from erroranalysis._internal.surrogate_error_tree import (
+    DEFAULT_MAX_DEPTH, DEFAULT_NUM_LEAVES, DEFAULT_MIN_CHILD_SAMPLES)
 
 
 class TestErrorAnalysisDashboard:
@@ -122,7 +124,12 @@ class TestErrorAnalysisDashboard:
                                            knn,
                                            dataset=X_test,
                                            true_y=y_test)
-        result = dashboard.input.debug_ml(global_explanation.features, [], [])
+        result = dashboard.input.debug_ml([global_explanation.features,
+                                           [],
+                                           [],
+                                           DEFAULT_MAX_DEPTH,
+                                           DEFAULT_NUM_LEAVES,
+                                           DEFAULT_MIN_CHILD_SAMPLES])
         assert WidgetRequestResponseConstants.ERROR not in result
         matrix_features = global_explanation.features[0:1]
         result = dashboard.input.matrix(matrix_features, [], [], True, 8)
@@ -169,7 +176,12 @@ def run_error_analysis_adult_census(X, y, categorical_features):
     dashboard = ErrorAnalysisDashboard(
         global_explanation, knn, dataset=X_test,
         true_y=y_test, categorical_features=categorical_features)
-    result = dashboard.input.debug_ml(global_explanation.features, [], [])
+    result = dashboard.input.debug_ml([global_explanation.features,
+                                       [],
+                                       [],
+                                       DEFAULT_MAX_DEPTH,
+                                       DEFAULT_NUM_LEAVES,
+                                       DEFAULT_MIN_CHILD_SAMPLES])
     assert WidgetRequestResponseConstants.ERROR not in result
     matrix_features = global_explanation.features[0:1]
     result = dashboard.input.matrix(matrix_features, [], [], True, 8)

--- a/responsibleai/responsibleai/_interfaces.py
+++ b/responsibleai/responsibleai/_interfaces.py
@@ -63,6 +63,7 @@ class ModelExplanationData:
 class ErrorAnalysisData:
     maxDepth: int
     numLeaves: int
+    minChildSamples: int
     tree: list
     matrix: list
     tree_features: List[str]


### PR DESCRIPTION
- added max depth parameter to control max tree depth
- added number of leaves parameter
- added minimum number of samples in one leaf parameter
- refactored some of the error analysis dashboard code to be more similar to model analysis - namely, take in an ErrorAnalysisData object like ModelAnalysis

![image](https://user-images.githubusercontent.com/24683184/135167479-236c42d5-2886-4d50-a54c-80671160b93c.png)
