### PR TITLE
fix multiple issues in instance view

### DIFF
--- a/libs/core-ui/src/lib/util/DatasetUtils.ts
+++ b/libs/core-ui/src/lib/util/DatasetUtils.ts
@@ -20,9 +20,11 @@ export function constructRows(
 ): any[] {
   const rows = [];
   for (let i = 0; i < viewedRows; i++) {
-    let index = cohortData[i][JointDataset.IndexLabel];
+    let index: number;
     if (indexes) {
       index = indexes[i];
+    } else {
+      index = cohortData[i][JointDataset.IndexLabel];
     }
     const row = jointDataset.getRow(index);
     if (filterFunction && filterFunction(row)) {

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/InstanceView/InstanceView.tsx
@@ -29,10 +29,11 @@ import {
 import { InstanceViewStyles } from "./InstanceView.styles";
 
 export interface ISelectionDetails {
-  selectedDatasetIndexes: number[];
-  selectedCorrectDatasetIndexes: number[];
+  selectedAllIndexes: number[];
+  selectedAllCorrectIndexes: number[];
+  selectedAllIncorrectIndexes: number[];
   selectedIncorrectDatasetIndexes: number[];
-  selectedAllSelectedIndexes: number[];
+  selectedCorrectDatasetIndexes: number[];
 }
 
 export interface IInstanceViewProps {
@@ -79,9 +80,10 @@ export class InstanceView extends React.Component<
     super(props);
     this.state = {
       selectionDetails: {
-        selectedAllSelectedIndexes: [],
+        selectedAllCorrectIndexes: [],
+        selectedAllIncorrectIndexes: [],
+        selectedAllIndexes: [],
         selectedCorrectDatasetIndexes: [],
-        selectedDatasetIndexes: [],
         selectedIncorrectDatasetIndexes: []
       }
     };
@@ -131,9 +133,7 @@ export class InstanceView extends React.Component<
             metadata={this.context.modelMetadata}
             selectedCohort={this.props.selectedCohort}
             messages={this.props.messages}
-            inspectedIndexes={
-              this.state.selectionDetails.selectedAllSelectedIndexes
-            }
+            inspectedIndexes={this.state.selectionDetails.selectedAllIndexes}
             selectedWeightVector={this.props.selectedWeightVector}
             weightOptions={this.props.weightOptions}
             weightLabels={this.props.weightLabels}
@@ -211,11 +211,9 @@ export class InstanceView extends React.Component<
               messages={this.props.messages}
               dataView={DataViewKeys.SelectedInstances}
               setSelectedIndexes={this.updateAllSelectedIndexes.bind(this)}
-              selectedIndexes={
-                this.state.selectionDetails.selectedAllSelectedIndexes
-              }
+              selectedIndexes={this.state.selectionDetails.selectedAllIndexes}
               allSelectedIndexes={
-                this.state.selectionDetails.selectedAllSelectedIndexes
+                this.state.selectionDetails.selectedAllIndexes
               }
               selectedCohort={this.props.selectedCohort}
               setWhatIfDatapoint={this.props.setWhatIfDatapoint}
@@ -231,13 +229,11 @@ export class InstanceView extends React.Component<
               messages={this.props.messages}
               customPoints={this.props.customPoints}
               dataView={DataViewKeys.SelectedInstances}
-              setSelectedIndexes={this.updateAllSelectedIndexes.bind(this)}
-              selectedIndexes={
-                this.state.selectionDetails.selectedAllSelectedIndexes
-              }
-              allSelectedIndexes={
-                this.state.selectionDetails.selectedAllSelectedIndexes
-              }
+              setSelectedIndexes={(_: number[]): void => {
+                // do nothing.
+              }}
+              selectedIndexes={[]}
+              allSelectedIndexes={[]}
               selectedCohort={this.props.selectedCohort}
               setWhatIfDatapoint={(): void => {
                 // do nothing.
@@ -263,27 +259,23 @@ export class InstanceView extends React.Component<
           selectionDetails.selectedCorrectDatasetIndexes;
         let selectedIncorrectIndexes =
           selectionDetails.selectedIncorrectDatasetIndexes;
-        const selectedAllSelectedIndexes =
-          selectionDetails.selectedAllSelectedIndexes;
+        const selectedAllIndexes = [...selectionDetails.selectedAllIndexes];
         // If going from AllSelectedTab, need to update the other arrays
         if (props.activePredictionTab === PredictionTabKeys.AllSelectedTab) {
           selectedCorrectIndexes = selectedCorrectIndexes.filter((index) =>
-            selectedAllSelectedIndexes.includes(index)
+            selectedAllIndexes.includes(index)
           );
           selectedIncorrectIndexes = selectedIncorrectIndexes.filter((index) =>
-            selectedAllSelectedIndexes.includes(index)
+            selectedAllIndexes.includes(index)
           );
         }
-        const selectedIndexes = [
-          ...selectedCorrectIndexes,
-          ...selectedIncorrectIndexes
-        ];
         this.props.setActivePredictionTab(PredictionTabKeys[option.key]);
         return {
           selectionDetails: {
-            selectedAllSelectedIndexes,
+            selectedAllCorrectIndexes: selectedCorrectIndexes,
+            selectedAllIncorrectIndexes: selectedIncorrectIndexes,
+            selectedAllIndexes,
             selectedCorrectDatasetIndexes: selectedCorrectIndexes,
-            selectedDatasetIndexes: selectedIndexes,
             selectedIncorrectDatasetIndexes: selectedIncorrectIndexes
           }
         };
@@ -310,9 +302,10 @@ export class InstanceView extends React.Component<
       ];
       return {
         selectionDetails: {
-          selectedAllSelectedIndexes: selectedIndexes,
+          selectedAllCorrectIndexes: selectedCorrectIndexes,
+          selectedAllIncorrectIndexes: selectedIncorrectIndexes,
+          selectedAllIndexes: selectedIndexes,
           selectedCorrectDatasetIndexes: selectedCorrectIndexes,
-          selectedDatasetIndexes: selectedIndexes,
           selectedIncorrectDatasetIndexes: selectedIncorrectIndexes
         }
       };
@@ -334,9 +327,10 @@ export class InstanceView extends React.Component<
       ];
       return {
         selectionDetails: {
-          selectedAllSelectedIndexes: selectedIndexes,
+          selectedAllCorrectIndexes: selectedCorrectIndexes,
+          selectedAllIncorrectIndexes: selectedIncorrectIndexes,
+          selectedAllIndexes: selectedIndexes,
           selectedCorrectDatasetIndexes: selectedCorrectIndexes,
-          selectedDatasetIndexes: selectedIndexes,
           selectedIncorrectDatasetIndexes: selectedIncorrectIndexes
         }
       };
@@ -349,12 +343,21 @@ export class InstanceView extends React.Component<
       state: Readonly<IInstanceViewState>
     ): IInstanceViewState => {
       const selectionDetails = state.selectionDetails;
+      const correctDatasetIndexes =
+        selectionDetails.selectedCorrectDatasetIndexes.filter((value) =>
+          indexes.includes(value)
+        );
+      const incorrectDatasetIndexes =
+        selectionDetails.selectedIncorrectDatasetIndexes.filter((value) =>
+          indexes.includes(value)
+        );
       return {
         selectionDetails: {
-          selectedAllSelectedIndexes: indexes,
+          selectedAllCorrectIndexes: correctDatasetIndexes,
+          selectedAllIncorrectIndexes: incorrectDatasetIndexes,
+          selectedAllIndexes: indexes,
           selectedCorrectDatasetIndexes:
             selectionDetails.selectedCorrectDatasetIndexes,
-          selectedDatasetIndexes: selectionDetails.selectedDatasetIndexes,
           selectedIncorrectDatasetIndexes:
             selectionDetails.selectedIncorrectDatasetIndexes
         }
@@ -369,24 +372,48 @@ export class InstanceView extends React.Component<
       const classNames = InstanceViewStyles();
       let selectionText = "";
       switch (type) {
-        case SelectionType.AllSelectionType:
+        case SelectionType.AllSelectionType: {
           selectionText = localization.formatString(
             localization.ErrorAnalysis.InstanceView.selection,
-            this.state.selectionDetails.selectedAllSelectedIndexes.length
+            this.state.selectionDetails.selectedAllIndexes.length
           );
           break;
-        case SelectionType.CorrectSelectionType:
+        }
+        case SelectionType.CorrectSelectionType: {
+          let countCorrect: number;
+          if (
+            this.props.activePredictionTab === PredictionTabKeys.AllSelectedTab
+          ) {
+            countCorrect =
+              this.state.selectionDetails.selectedAllCorrectIndexes.length;
+          } else {
+            countCorrect =
+              this.state.selectionDetails.selectedCorrectDatasetIndexes.length;
+          }
           selectionText = localization.formatString(
             localization.ErrorAnalysis.InstanceView.selection,
-            this.state.selectionDetails.selectedCorrectDatasetIndexes.length
+            countCorrect
           );
           break;
-        case SelectionType.IncorrectSelectionType:
+        }
+        case SelectionType.IncorrectSelectionType: {
+          let countIncorrect: number;
+          if (
+            this.props.activePredictionTab === PredictionTabKeys.AllSelectedTab
+          ) {
+            countIncorrect =
+              this.state.selectionDetails.selectedAllIncorrectIndexes.length;
+          } else {
+            countIncorrect =
+              this.state.selectionDetails.selectedIncorrectDatasetIndexes
+                .length;
+          }
           selectionText = localization.formatString(
             localization.ErrorAnalysis.InstanceView.selection,
-            this.state.selectionDetails.selectedIncorrectDatasetIndexes.length
+            countIncorrect
           );
           break;
+        }
         default:
           break;
       }


### PR DESCRIPTION
There seem to be multiple issues in instance view in ErrorAnalysisDashboard when I tried to use it:
1.) When selecting multiple rows in correct and incorrect panels, and going to all selected, if I remove a point in the middle all of the  points below get removed
2.) When removing points in the all selected panel, the count does not get updates in the correct/incorrect panels until they are selected
3.) When using what if, you can select points for some reason - but when selecting them magically points get selected from the original dataset using the same index, which creates a lot of confusion.  The fix here is to make sure what if points are not selectable, since the inspect view is anyway not useful for them.