### PR TITLE
fix quantile binning toggle should stay on when making actions

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixOptions/MatrixOptions.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Matrix/MatrixOptions/MatrixOptions.tsx
@@ -35,6 +35,7 @@ export class MatrixOptions extends React.Component<IMatrixOptionsProps> {
       <Stack horizontal tokens={stackTokens}>
         <Stack.Item className={classNames.toggleStackStyle}>
           <Toggle
+            defaultChecked={this.props.quantileBinning}
             label={
               <div>
                 {localization.ErrorAnalysis.MatrixOptions.quantileBinningLabel}
@@ -75,7 +76,7 @@ export class MatrixOptions extends React.Component<IMatrixOptionsProps> {
           <Slider
             min={2}
             max={20}
-            defaultValue={8}
+            defaultValue={this.props.binningThreshold}
             showValue
             onChanged={this.onBinsSliderChanged}
             disabled={!this.props.isEnabled}


### PR DESCRIPTION
fixes issue:
https://github.com/microsoft/responsible-ai-widgets/issues/917

- keep quantile binning on when taking actions like changing the features in the heatmap that re-render the view
- noticed similar issue with binning slider as well, fixed in this PR too