### PR TITLE
fix error rate gradient for classification scenario

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Gradient/Gradient.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Gradient/Gradient.tsx
@@ -23,11 +23,16 @@ export class Gradient extends React.Component<IGradientProps> {
     if (this.props.isRate) {
       maxValue = maxValue * 100;
     }
+    const gradentMidValue = (1 / (maxValue / 100)) * this.props.minPct;
+    let gradientMidPct: number;
+    if (this.props.isRate) {
+      gradientMidPct = 100 - gradentMidValue * 100;
+    } else {
+      gradientMidPct = 100 - gradentMidValue;
+    }
     const errorRateLineHeight =
       errorRateRectHeight - (this.props.value / maxValue) * errorRateRectHeight;
-    const gradientMidPct = `${
-      100 - (1 / (maxValue / 100)) * this.props.minPct
-    }%`;
+    const gradientMidPctStr = `${gradientMidPct}%`;
     const minColor = this.props.isErrorMetric
       ? ColorPalette.MinErrorColor
       : ColorPalette.MinMetricColor;
@@ -44,8 +49,8 @@ export class Gradient extends React.Component<IGradientProps> {
           gradientTransform="rotate(90)"
         >
           <stop offset="0%" stopColor={maxColor} />
-          <stop offset={gradientMidPct} stopColor={minColor} />
-          <stop offset={gradientMidPct} stopColor={errorAvgColor} />
+          <stop offset={gradientMidPctStr} stopColor={minColor} />
+          <stop offset={gradientMidPctStr} stopColor={errorAvgColor} />
           <stop offset="100%" stopColor={errorAvgColor} />
         </linearGradient>
         <rect


### PR DESCRIPTION
fixes issue:
https://github.com/microsoft/responsible-ai-widgets/issues/916

The gradient before this change looked incorrect as it doesn't include the gray colors from 0 to the root node's error rate:
![image](https://user-images.githubusercontent.com/24683184/135344839-51de1251-dfea-40b2-9d6d-eff58a11f651.png)

The gradient for regression scenario (mean squared error) looks much better:
![image](https://user-images.githubusercontent.com/24683184/135345076-c7491d0a-0bbb-48d9-8231-8a698989d817.png)
