### PR TITLE
fix running what if on categorical numeric values in error analysis dashboard

### DIFF
--- a/libs/core-ui/src/lib/util/getFeatureOptions.ts
+++ b/libs/core-ui/src/lib/util/getFeatureOptions.ts
@@ -15,7 +15,10 @@ export function getFeatureOptions(
       const meta = jointDataset.metaDict[key];
       const options = meta.isCategorical
         ? meta.sortedCategoricalValues?.map(
-            (optionText: string, index: number) => {
+            (optionText: string | number, index: number) => {
+              if (typeof optionText !== "string") {
+                optionText = optionText.toString();
+              }
               return { key: index, text: optionText };
             }
           )

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/WhatIf/WhatIf.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/WhatIf/WhatIf.tsx
@@ -6,7 +6,8 @@ import {
   ErrorCohort,
   defaultModelAssessmentContext,
   ModelAssessmentContext,
-  FabricStyles
+  FabricStyles,
+  getFeatureOptions
 } from "@responsible-ai/core-ui";
 import { WhatIfConstants, WhatIfPanel } from "@responsible-ai/interpret";
 import { localization } from "@responsible-ai/localization";
@@ -70,27 +71,8 @@ export class WhatIf extends React.Component<IWhatIfProps, IWhatIfState> {
     this.createCopyOfFirstRow();
     this.buildRowOptions();
 
-    const featuresOption: IDropdownOption[] = new Array(
-      this.context.jointDataset.datasetFeatureCount
-    )
-      .fill(0)
-      .map((_, index) => {
-        const key = JointDataset.DataLabelRoot + index.toString();
-        const meta = this.context.jointDataset.metaDict[key];
-        const options = meta.isCategorical
-          ? meta.sortedCategoricalValues?.map((optionText, index) => {
-              return { key: index, text: optionText };
-            })
-          : undefined;
-        return {
-          data: {
-            categoricalOptions: options,
-            fullLabel: meta.label.toLowerCase()
-          },
-          key,
-          text: meta.abbridgedLabel
-        };
-      });
+    const featuresOption = getFeatureOptions(this.context.jointDataset);
+
     this.setState({ featuresOption, filteredFeatureList: featuresOption });
   }
 


### PR DESCRIPTION
A user ran into an issue where the error analysis dashboard was not displaying the values in their dropdowns correctly in the what-if tab, and they couldn't run what if.
The issue only appears for columns with numeric values that were marked as categorical.
Note values can be numeric but still represent categories, as there is no ordering relationship between the values.
This PR fixes the UI issue by converting the numeric values to string in the dropdown text area, which can't handle numeric values directly.