### PR TITLE
Add __init__.py file to causal schema directory

### DIFF
--- a/responsibleai/responsibleai/_tools/causal/dashboard_schemas/__init__.py
+++ b/responsibleai/responsibleai/_tools/causal/dashboard_schemas/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Causal dashboard schema module."""


### PR DESCRIPTION
The __init__.py allows to package the data files in the python package. Without this file the package is having missing schema direcotyr for causal