### PR TITLE
display message bar after saving a cohort in error analysis dashboard

### DIFF
--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Navigation/Navigation.styles.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Navigation/Navigation.styles.ts
@@ -9,16 +9,36 @@ import {
 } from "office-ui-fabric-react";
 
 export interface INavigationStyles {
+  breadcrumbItemWidth: IStyle;
+  content: IStyle;
+  dismissal: IStyle;
+  dismissSingleLine: IStyle;
+  iconContainer: IStyle;
   navigation: IStyle;
-  breadcrumb: IStyle;
+  root: IStyle;
+  text: IStyle;
 }
 
 export const navigationStyles: () => IProcessedStyleSet<INavigationStyles> =
   () => {
     const theme = getTheme();
     return mergeStyleSets<INavigationStyles>({
-      breadcrumb: {
-        padding: "0px 0px 0px 10px"
+      breadcrumbItemWidth: {
+        width: "500px"
+      },
+      content: {
+        margin: "0"
+      },
+      dismissal: {
+        height: "24px",
+        padding: "0"
+      },
+      dismissSingleLine: {
+        margin: "0"
+      },
+      iconContainer: {
+        height: "20px",
+        margin: "4px 8px 0 12px"
       },
       navigation: {
         backgroundColor: theme.palette.white,
@@ -27,6 +47,15 @@ export const navigationStyles: () => IProcessedStyleSet<INavigationStyles> =
         color: theme.palette.black,
         height: "25px",
         width: "100%"
+      },
+      root: {
+        height: "24px",
+        margin: "0",
+        minHeight: "24px"
+      },
+      text: {
+        height: "24px",
+        margin: "4px 0 0"
       }
     });
   };

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Navigation/Navigation.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Controls/Navigation/Navigation.tsx
@@ -7,9 +7,13 @@ import {
   IBreadcrumbItem,
   IBreadcrumbStyleProps,
   IBreadcrumbStyles,
+  IMessageBarStyles,
+  IRenderFunction,
   IStyleFunctionOrObject,
   Link,
-  IRenderFunction
+  MessageBar,
+  MessageBarType,
+  Stack
 } from "office-ui-fabric-react";
 import React from "react";
 
@@ -27,13 +31,15 @@ export interface INavigationProps {
   viewType: ViewTypeKeys;
   activeGlobalTab: GlobalTabKeys;
   activePredictionTab: PredictionTabKeys;
+  showMessageBar: boolean;
+  closeMessageBar: () => void;
 }
 
 const breadcrumbStyle: IStyleFunctionOrObject<
   IBreadcrumbStyleProps,
   IBreadcrumbStyles
 > = {
-  root: { margin: "3px 0px 1px" }
+  root: { margin: "3px 0px 1px 10px" }
 };
 
 export class Navigation extends React.Component<INavigationProps> {
@@ -102,18 +108,41 @@ export class Navigation extends React.Component<INavigationProps> {
       }
     }
     const classNames = navigationStyles();
+    const messageBarStyles: IMessageBarStyles = {
+      content: classNames.content,
+      dismissal: classNames.dismissal,
+      dismissSingleLine: classNames.dismissSingleLine,
+      iconContainer: classNames.iconContainer,
+      root: classNames.root,
+      text: classNames.text
+    };
     return (
       <div className={classNames.navigation}>
-        <div className={classNames.breadcrumb}>
-          <Breadcrumb
-            items={items}
-            maxDisplayedItems={10}
-            ariaLabel="Navigation"
-            overflowAriaLabel="More links"
-            onRenderItem={this._onRenderItem}
-            styles={breadcrumbStyle}
-          />
-        </div>
+        <Stack horizontal horizontalAlign="space-between">
+          <Stack.Item className={classNames.breadcrumbItemWidth}>
+            <Breadcrumb
+              items={items}
+              maxDisplayedItems={10}
+              ariaLabel="Navigation"
+              overflowAriaLabel="More links"
+              onRenderItem={this._onRenderItem}
+              styles={breadcrumbStyle}
+            />
+          </Stack.Item>
+          {this.props.showMessageBar && (
+            <Stack.Item>
+              <MessageBar
+                messageBarType={MessageBarType.success}
+                isMultiline={false}
+                onDismiss={() => this.props.closeMessageBar()}
+                className={classNames.root}
+                styles={messageBarStyles}
+              >
+                {localization.ErrorAnalysis.Navigation.cohortSaved}
+              </MessageBar>
+            </Stack.Item>
+          )}
+        </Stack>
       </div>
     );
   }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/ErrorAnalysisDashboard.tsx
@@ -331,6 +331,7 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
           ? WeightVectors.AbsAvg
           : 0,
       selectedWhatIfIndex: undefined,
+      showMessageBar: false,
       treeViewState: createInitialTreeViewState(),
       viewType: ViewTypeKeys.ErrorAnalysisView,
       weightVectorLabels,
@@ -380,6 +381,8 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
             viewType={this.state.viewType}
             activeGlobalTab={this.state.activeGlobalTab}
             activePredictionTab={this.state.predictionTab}
+            showMessageBar={this.state.showMessageBar}
+            closeMessageBar={this.closeMessageBar}
           />
           <MainMenu
             viewExplanation={this.viewExplanation.bind(this)}
@@ -776,6 +779,10 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
     this.setState({ predictionTab });
   }
 
+  private closeMessageBar = (): void => {
+    this.setState({ showMessageBar: false });
+  };
+
   private onWeightVectorChange = (weightOption: WeightVectorOption): void => {
     this.state.jointDataset.buildLocalFlattenMatrix(weightOption);
     this.state.cohorts.forEach((errorCohort) =>
@@ -805,7 +812,8 @@ export class ErrorAnalysisDashboard extends React.PureComponent<
     this.setState((prevState) => ({
       baseCohort: switchNew ? savedCohort : prevState.baseCohort,
       cohorts: newCohorts,
-      selectedCohort: switchNew ? savedCohort : prevState.selectedCohort
+      selectedCohort: switchNew ? savedCohort : prevState.selectedCohort,
+      showMessageBar: true
     }));
   };
 }

--- a/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardState.ts
+++ b/libs/error-analysis/src/lib/ErrorAnalysisDashboard/Interfaces/IErrorAnalysisDashboardState.ts
@@ -48,6 +48,7 @@ export interface IErrorAnalysisDashboardState
   selectedWhatIfIndex: number | undefined;
   editedCohort: ErrorCohort;
   selectedFeatures: string[];
+  showMessageBar: boolean;
   treeViewState: ITreeViewRendererState;
   matrixAreaState: IMatrixAreaState;
   matrixFilterState: IMatrixFilterState;

--- a/libs/localization/src/lib/en.json
+++ b/libs/localization/src/lib/en.json
@@ -289,6 +289,7 @@
       "selectorLabel": "Select metric"
     },
     "Navigation": {
+      "cohortSaved": "New cohort is saved! See Cohort list under Cohort settings.",
       "dataExplorer": "Data explorer",
       "errorExplorer": "Error explorer",
       "globalExplanation": "Global explanation",


### PR DESCRIPTION
Fixes issue: https://github.com/microsoft/responsible-ai-widgets/issues/242
Display message bar after saving a cohort in error analysis dashboard.

Sample screenshot in test app:
![image](https://user-images.githubusercontent.com/24683184/141052906-58815b0f-2198-4727-917d-65f63aef3ce4.png)
