### PR TITLE
Bug fix: Feature importance for node with 0 error

### DIFF
--- a/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
+++ b/libs/model-assessment/src/lib/ModelAssessmentDashboard/Controls/IndividualFeatureImportanceView.tsx
@@ -250,10 +250,13 @@ export class IndividualFeatureImportanceView extends React.Component<
           (row) =>
             row[JointDataset.TrueYLabel] !== row[JointDataset.PredictedYLabel]
         );
+      const noIncorrectItem = firstIncorrectItemIndex === -1;
 
       groups = [
         {
-          count: firstIncorrectItemIndex,
+          count: noIncorrectItem
+            ? this.props.selectedCohort.cohort.filteredData.length
+            : firstIncorrectItemIndex,
           key: "groupCorrect",
           level: 0,
           name: localization.ModelAssessment.FeatureImportances
@@ -261,9 +264,10 @@ export class IndividualFeatureImportanceView extends React.Component<
           startIndex: 0
         },
         {
-          count:
-            this.props.selectedCohort.cohort.filteredData.length -
-            firstIncorrectItemIndex,
+          count: noIncorrectItem
+            ? 0
+            : this.props.selectedCohort.cohort.filteredData.length -
+              firstIncorrectItemIndex,
           key: "groupIncorrect",
           level: 0,
           name: localization.ModelAssessment.FeatureImportances


### PR DESCRIPTION
This PR fixes the bug when the tree node has 0 errors and N correct, the raw data table shows the opposite with N+1 errors and -1 correct. 
We should consider the case when the  firstIncorrectItemIndex is -1 (no incorrect item) separately.