### PR TITLE
add support for special classification outcome filter to error analysis backend for model analysis

### DIFF
--- a/erroranalysis/erroranalysis/_internal/cohort_filter.py
+++ b/erroranalysis/erroranalysis/_internal/cohort_filter.py
@@ -6,33 +6,97 @@ import pandas as pd
 
 from erroranalysis._internal.constants import (METHOD, METHOD_EXCLUDES,
                                                METHOD_INCLUDES, PRED_Y,
-                                               ROW_INDEX, TRUE_Y)
+                                               ROW_INDEX, TRUE_Y, ModelTask)
+from erroranalysis._internal.metrics import get_ordered_classes
 
+COLUMN = 'column'
 METHOD_EQUAL = 'equal'
 METHOD_GREATER = 'greater'
 METHOD_LESS = 'less'
 METHOD_LESS_AND_EQUAL = 'less and equal'
 METHOD_GREATER_AND_EQUAL = 'greater and equal'
 METHOD_RANGE = 'in the range of'
+MODEL = 'model'
+CLASSIFICATION_OUTCOME = 'Classification outcome'
 
 
-def filter_from_cohort(df, filters, composite_filters,
-                       feature_names, true_y,
-                       categorical_features, categories,
-                       pred_y=None):
+def filter_from_cohort(analyzer, filters, composite_filters):
+    df = analyzer.dataset
+    feature_names = analyzer.feature_names
+    true_y = analyzer.true_y
+    categorical_features = analyzer.categorical_features
+    categories = analyzer.categories
     if not isinstance(df, pd.DataFrame):
         df = pd.DataFrame(df, columns=feature_names)
     else:
         # Note: we make a non-deep copy of the input dataframe since
         # we will add columns below
         df = df.copy()
-    df[TRUE_Y] = true_y
-    if pred_y is not None:
-        df[PRED_Y] = pred_y
-    df[ROW_INDEX] = np.arange(0, len(true_y))
+    add_filter_cols(analyzer, df, filters, true_y)
     df = apply_recursive_filter(df, filters, categorical_features, categories)
     df = apply_recursive_filter(df, composite_filters,
                                 categorical_features, categories)
+    df = post_process_df(df)
+    return df
+
+
+def filter_has_classification_outcome(analyzer, filters):
+    model_task = analyzer.model_task
+    # For classification task, check if classification
+    # outcome included in filters, and if it is then
+    # compute the necessary column data on the fly
+    if model_task == ModelTask.CLASSIFICATION and filters:
+        for filter in filters:
+            if COLUMN in filter:
+                column = filter[COLUMN]
+                if column == CLASSIFICATION_OUTCOME:
+                    return True
+    return False
+
+
+def add_filter_cols(analyzer, df, filters, true_y):
+    has_classification_outcome = filter_has_classification_outcome(analyzer,
+                                                                   filters)
+    df[TRUE_Y] = true_y
+    is_model_analyzer = hasattr(analyzer, MODEL)
+    if not is_model_analyzer:
+        df[PRED_Y] = analyzer.pred_y
+    df[ROW_INDEX] = np.arange(0, len(true_y))
+    if has_classification_outcome:
+        if PRED_Y in df:
+            pred_y = df[PRED_Y]
+        else:
+            # calculate directly via prediction on model
+            pred_y = analyzer.model.predict(df.drop(columns=[TRUE_Y,
+                                                             ROW_INDEX]))
+        classes = get_ordered_classes(analyzer.classes, true_y, pred_y)
+        # calculate classification outcome and add to df
+        classification_outcome = []
+        if not isinstance(pred_y, np.ndarray):
+            pred_y = np.array(pred_y)
+        if not isinstance(true_y, np.ndarray):
+            true_y = np.array(true_y)
+        for i in range(len(true_y)):
+            if true_y[i] == pred_y[i]:
+                if true_y[i] == classes[0]:
+                    # True negative == 0
+                    classification_outcome.append(3)
+                else:
+                    # True positive == 3
+                    classification_outcome.append(3)
+            else:
+                if true_y[i] == classes[0]:
+                    # False negative == 2
+                    classification_outcome.append(2)
+                else:
+                    # False positive == 1
+                    classification_outcome.append(1)
+        df[CLASSIFICATION_OUTCOME] = classification_outcome
+
+
+def post_process_df(df):
+    if CLASSIFICATION_OUTCOME in list(df.columns):
+        df = df.drop(columns=CLASSIFICATION_OUTCOME)
     return df
 
 
@@ -49,7 +113,7 @@ def build_query(filters, categorical_features, categories):
         if METHOD in filter:
             method = filter[METHOD]
             arg0 = str(filter['arg'][0])
-            colname = filter['column']
+            colname = filter[COLUMN]
             if method == METHOD_GREATER:
                 queries.append("`" + colname + "` > " + arg0)
             elif method == METHOD_LESS:
@@ -104,13 +168,19 @@ def build_cat_bounds_query(filter, colname, method,
         operator = " != "
     else:
         operator = " == "
+    is_categorical = False
+    if categorical_features:
+        is_categorical = colname in categorical_features
     for arg in filter['arg']:
-        cat_idx = categorical_features.index(colname)
-        if isinstance(categories[cat_idx][arg], str):
-            arg_cat = "'{}'".format(str(categories[cat_idx][arg]))
+        if is_categorical:
+            cat_idx = categorical_features.index(colname)
+            if isinstance(categories[cat_idx][arg], str):
+                arg_val = "'{}'".format(str(categories[cat_idx][arg]))
+            else:
+                arg_val = "{}".format(str(categories[cat_idx][arg]))
         else:
-            arg_cat = "{}".format(str(categories[cat_idx][arg]))
-        bounds.append("`{}`{}{}".format(colname, operator, arg_cat))
+            arg_val = arg
+        bounds.append("`{}`{}{}".format(colname, operator, arg_val))
     if method == METHOD_EXCLUDES:
         return ' & '.join(bounds)
     else:

--- a/erroranalysis/erroranalysis/_internal/matrix_filter.py
+++ b/erroranalysis/erroranalysis/_internal/matrix_filter.py
@@ -14,7 +14,7 @@ from erroranalysis._internal.constants import (DIFF, PRED_Y, ROW_INDEX, TRUE_Y,
                                                MatrixParams, Metrics,
                                                ModelTask,
                                                metric_to_display_name)
-from erroranalysis._internal.metrics import (get_ordered_labels,
+from erroranalysis._internal.metrics import (get_ordered_classes,
                                              is_multi_agg_metric,
                                              metric_to_func)
 
@@ -53,26 +53,12 @@ def compute_matrix(analyzer, features, filters, composite_filters,
     if features[0] is None and features[1] is None:
         raise ValueError(
             'One or two features must be specified to compute the heat map')
-    is_model_analyzer = hasattr(analyzer, 'model')
-    if is_model_analyzer:
-        filtered_df = filter_from_cohort(analyzer.dataset,
-                                         filters,
-                                         composite_filters,
-                                         analyzer.feature_names,
-                                         analyzer.true_y,
-                                         analyzer.categorical_features,
-                                         analyzer.categories)
-    else:
-        filtered_df = filter_from_cohort(analyzer.dataset,
-                                         filters,
-                                         composite_filters,
-                                         analyzer.feature_names,
-                                         analyzer.true_y,
-                                         analyzer.categorical_features,
-                                         analyzer.categories,
-                                         analyzer.pred_y)
+    filtered_df = filter_from_cohort(analyzer,
+                                     filters,
+                                     composite_filters)
     true_y = filtered_df[TRUE_Y]
     dropped_cols = [TRUE_Y, ROW_INDEX]
+    is_model_analyzer = hasattr(analyzer, 'model')
     if not is_model_analyzer:
         pred_y = filtered_df[PRED_Y]
         dropped_cols.append(PRED_Y)
@@ -175,8 +161,8 @@ def compute_matrix(analyzer, features, filters, composite_filters,
                                        colnames=[feat2])
         else:
             if is_multi_agg_metric(metric):
-                ordered_labels = get_ordered_labels(analyzer.classes,
-                                                    true_y, pred_y)
+                ordered_labels = get_ordered_classes(analyzer.classes,
+                                                     true_y, pred_y)
                 aggfunc = _MultiMetricAggFunc(metric_to_func[metric],
                                               ordered_labels, metric)
             else:
@@ -243,8 +229,8 @@ def compute_matrix(analyzer, features, filters, composite_filters,
         # Compute the given metric for each group, if not using error rate
         if metric != Metrics.ERROR_RATE:
             if is_multi_agg_metric(metric):
-                ordered_labels = get_ordered_labels(analyzer.classes,
-                                                    true_y, pred_y)
+                ordered_labels = get_ordered_classes(analyzer.classes,
+                                                     true_y, pred_y)
                 aggfunc = _MultiMetricAggFunc(metric_to_func[metric],
                                               ordered_labels, metric)
             else:

--- a/erroranalysis/erroranalysis/_internal/metrics.py
+++ b/erroranalysis/erroranalysis/_internal/metrics.py
@@ -37,7 +37,7 @@ def macro_f1_score(y_true, y_pred):
     return f1_score(y_true, y_pred, average=MACRO)
 
 
-def get_ordered_labels(classes, true_y, pred_y):
+def get_ordered_classes(classes, true_y, pred_y):
     # If classes is none, or disagrees with labels from true and predicted
     # arrays, return the sorted set of labels.
     # Otherwise return classes as it provides the correct ordering and any

--- a/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
+++ b/erroranalysis/erroranalysis/_internal/surrogate_error_tree.py
@@ -21,7 +21,7 @@ from erroranalysis._internal.constants import (DIFF, LEAF_INDEX, METHOD,
                                                metric_to_display_name,
                                                precision_metrics,
                                                recall_metrics)
-from erroranalysis._internal.metrics import get_ordered_labels, metric_to_func
+from erroranalysis._internal.metrics import get_ordered_classes, metric_to_func
 
 MODEL = 'model'
 DEFAULT_MAX_DEPTH = 3
@@ -75,27 +75,13 @@ def compute_error_tree(analyzer,
         num_leaves = DEFAULT_NUM_LEAVES
     if min_child_samples is None:
         min_child_samples = DEFAULT_MIN_CHILD_SAMPLES
-    is_model_analyzer = hasattr(analyzer, MODEL)
-    if is_model_analyzer:
-        filtered_df = filter_from_cohort(analyzer.dataset,
-                                         filters,
-                                         composite_filters,
-                                         analyzer.feature_names,
-                                         analyzer.true_y,
-                                         analyzer.categorical_features,
-                                         analyzer.categories)
-    else:
-        filtered_df = filter_from_cohort(analyzer.dataset,
-                                         filters,
-                                         composite_filters,
-                                         analyzer.feature_names,
-                                         analyzer.true_y,
-                                         analyzer.categorical_features,
-                                         analyzer.categories,
-                                         analyzer.pred_y)
+    filtered_df = filter_from_cohort(analyzer,
+                                     filters,
+                                     composite_filters)
     row_index = filtered_df[ROW_INDEX]
     true_y = filtered_df[TRUE_Y]
     dropped_cols = [TRUE_Y, ROW_INDEX]
+    is_model_analyzer = hasattr(analyzer, MODEL)
     if not is_model_analyzer:
         pred_y = filtered_df[PRED_Y]
         dropped_cols.append(PRED_Y)
@@ -457,7 +443,7 @@ def compute_metric_value(func, classes, true_y, pred_y, metric):
                           metric == Metrics.PRECISION_SCORE or
                           metric == Metrics.F1_SCORE)
     if requires_pos_label:
-        ordered_labels = get_ordered_labels(classes, true_y, pred_y)
+        ordered_labels = get_ordered_classes(classes, true_y, pred_y)
         if ordered_labels is not None and len(ordered_labels) == 2:
             return func(true_y, pred_y, pos_label=ordered_labels[1])
     return func(true_y, pred_y)

--- a/erroranalysis/erroranalysis/version.py
+++ b/erroranalysis/erroranalysis/version.py
@@ -4,5 +4,5 @@
 name = 'erroranalysis'
 _major = '0'
 _minor = '1'
-_patch = '27'
+_patch = '28'
 version = '{}.{}.{}'.format(_major, _minor, _patch)

--- a/erroranalysis/tests/test_cohort_filter.py
+++ b/erroranalysis/tests/test_cohort_filter.py
@@ -8,12 +8,14 @@ from common_utils import (create_iris_data, create_simple_titanic_data,
                           create_titanic_pipeline)
 
 from erroranalysis._internal.cohort_filter import filter_from_cohort
-from erroranalysis._internal.constants import ROW_INDEX, TRUE_Y, ModelTask
+from erroranalysis._internal.constants import (
+    PRED_Y, ROW_INDEX, TRUE_Y, ModelTask)
 from erroranalysis._internal.error_analyzer import ModelAnalyzer
 
 TOL = 1e-10
 SEPAL_WIDTH = 'sepal width'
 EMBARKED = 'embarked'
+CLASSIFICATION_OUTCOME = 'Classification outcome'
 
 
 class TestCohortFilter(object):
@@ -157,6 +159,31 @@ class TestCohortFilter(object):
                            model_task,
                            filters=filters)
 
+    def test_cohort_filter_classification_outcome(self):
+        X_train, X_test, y_train, y_test, numeric, categorical = \
+            create_simple_titanic_data()
+        feature_names = categorical + numeric
+        clf = create_titanic_pipeline(X_train, y_train)
+        categorical_features = categorical
+        # the indexes 1, 2 correspond to false positives and false negatives
+        filters = [{'arg': [1, 2],
+                    'column': CLASSIFICATION_OUTCOME,
+                    'method': 'includes'}]
+        pred_y = clf.predict(X_test)
+        validation_data = create_validation_data(X_test, y_test, pred_y)
+        validation_filter = validation_data[PRED_Y] != validation_data[TRUE_Y]
+        validation_data = validation_data.loc[validation_filter]
+        validation_data = validation_data.drop(columns=PRED_Y)
+        model_task = ModelTask.CLASSIFICATION
+        run_error_analyzer(validation_data,
+                           clf,
+                           X_test,
+                           y_test,
+                           feature_names,
+                           categorical_features,
+                           model_task,
+                           filters=filters)
+
 
 def create_iris_pandas():
     X_train, X_test, y_train, y_test, feature_names, _ = create_iris_data()
@@ -167,10 +194,12 @@ def create_iris_pandas():
     return X_train, X_test, y_train, y_test, feature_names
 
 
-def create_validation_data(X_test, y_test):
+def create_validation_data(X_test, y_test, pred_y=None):
     validation_data = X_test.copy()
     validation_data[TRUE_Y] = y_test
     validation_data[ROW_INDEX] = np.arange(0, len(y_test))
+    if pred_y is not None:
+        validation_data[PRED_Y] = pred_y
     return validation_data
 
 
@@ -189,13 +218,9 @@ def run_error_analyzer(validation_data,
                                    feature_names,
                                    categorical_features,
                                    model_task=model_task)
-    filtered_data = filter_from_cohort(X_test,
+    filtered_data = filter_from_cohort(error_analyzer,
                                        filters,
-                                       composite_filters,
-                                       feature_names,
-                                       y_test,
-                                       categorical_features,
-                                       error_analyzer.categories)
+                                       composite_filters)
     # validate there is some data selected for each of the filters
     assert validation_data.shape[0] > 0
     assert validation_data.equals(filtered_data)

--- a/erroranalysis/tests/test_matrix_filter.py
+++ b/erroranalysis/tests/test_matrix_filter.py
@@ -25,7 +25,7 @@ from erroranalysis._internal.matrix_filter import (CATEGORY1, CATEGORY2, COUNT,
                                                    MATRIX, METRIC_NAME,
                                                    METRIC_VALUE, TN, TP,
                                                    VALUES)
-from erroranalysis._internal.metrics import (get_ordered_labels,
+from erroranalysis._internal.metrics import (get_ordered_classes,
                                              is_multi_agg_metric,
                                              metric_to_func)
 
@@ -359,13 +359,9 @@ def run_error_analyzer(model,
                                            num_bins=num_bins)
     validation_data = X_test
     if filters is not None or composite_filters is not None:
-        validation_data = filter_from_cohort(X_test,
+        validation_data = filter_from_cohort(error_analyzer,
                                              filters,
-                                             composite_filters,
-                                             feature_names,
-                                             y_test,
-                                             categorical_features,
-                                             error_analyzer.categories)
+                                             composite_filters)
         y_test = validation_data[TRUE_Y]
         validation_data = validation_data.drop(columns=[TRUE_Y, ROW_INDEX])
         if not isinstance(X_test, pd.DataFrame):
@@ -398,9 +394,9 @@ def get_expected_metric_error(error_analyzer, metric, model,
         pred_y = model.predict(validation_data)
         can_be_binary = error_analyzer.model_task == ModelTask.CLASSIFICATION
         if can_be_binary and metric != Metrics.ACCURACY_SCORE:
-            ordered_labels = get_ordered_labels(error_analyzer.classes,
-                                                y_test,
-                                                pred_y)
+            ordered_labels = get_ordered_classes(error_analyzer.classes,
+                                                 y_test,
+                                                 pred_y)
             if len(ordered_labels) == 2:
                 return func(y_test, pred_y, pos_label=ordered_labels[1])
         return func(y_test, pred_y)


### PR DESCRIPTION
In model analysis, a user can select the "Classification outcome" to be a filter for creating a new cohort.  However, the erroranalysis python package does not recognize this special filter.  If the user creates this filter and shifts to this cohort in model analysis, error analysis will fail because it does not recognize it.

The solution is to dynamically compute and add this column to the error analysis backend if this filter column name is detected when sent from the frontend.