### PR TITLE
Directory based state management for model analysis tools

### DIFF
--- a/responsibleai/responsibleai/_managers/causal_manager.py
+++ b/responsibleai/responsibleai/_managers/causal_manager.py
@@ -10,9 +10,10 @@ import pandas as pd
 from econml.solutions.causal_analysis import CausalAnalysis
 
 from responsibleai._data_validations import validate_train_test_categories
-from responsibleai._internal.constants import (ManagerNames,
-                                               SerializationAttributes)
+from responsibleai._internal.constants import ManagerNames
 from responsibleai._managers.base_manager import BaseManager
+from responsibleai._tools.shared.state_directory_management import \
+    DirectoryManager
 from responsibleai._tools.causal.causal_config import CausalConfig
 from responsibleai._tools.causal.causal_constants import (DefaultParams,
                                                           ModelTypes,
@@ -344,11 +345,10 @@ class CausalManager(BaseManager):
         causal_dir.mkdir(parents=True, exist_ok=True)
 
         # Save results to disk
-        results_path = causal_dir / SerializationAttributes.RESULTS_DIRECTORY
-        results_path.mkdir(parents=True, exist_ok=True)
         for result in self._results:
-            result_path = results_path / result.id
-            result.save(result_path)
+            directory_manager = DirectoryManager(parent_directory_path=path)
+            data_path = directory_manager.create_data_directory()
+            result.save(data_path)
 
     @staticmethod
     def _load(path, rai_insights):
@@ -363,12 +363,14 @@ class CausalManager(BaseManager):
         """
         inst = CausalManager.__new__(CausalManager)
 
-        causal_dir = Path(path)
-
         # Rehydrate results
-        results_path = causal_dir / SerializationAttributes.RESULTS_DIRECTORY
-        paths = results_path.resolve().glob('*')
-        inst.__dict__['_results'] = [CausalResult.load(p) for p in paths]
+        all_causal_dirs = DirectoryManager.list_sub_directories(path)
+        inst.__dict__['_results'] = []
+        for causal_dir in all_causal_dirs:
+            dm = DirectoryManager(parent_directory_path=path,
+                                  sub_directory_name=causal_dir)
+            causal_result = CausalResult.load(dm.get_data_directory())
+            inst.__dict__['_results'].append(causal_result)
 
         # Rehydrate model analysis data
         inst.__dict__['_train'] = rai_insights.train

--- a/responsibleai/responsibleai/_managers/explainer_manager.py
+++ b/responsibleai/responsibleai/_managers/explainer_manager.py
@@ -27,6 +27,8 @@ from responsibleai._internal.constants import (ExplanationKeys, ListProperties,
                                                ManagerNames, Metadata)
 from responsibleai._managers.base_manager import BaseManager
 from responsibleai.exceptions import UserConfigValidationException
+from responsibleai._tools.shared.state_directory_management import \
+    DirectoryManager
 
 SPARSE_NUM_FEATURES_THRESHOLD = 1000
 IS_RUN = 'is_run'
@@ -301,13 +303,17 @@ class ExplainerManager(BaseManager):
         """
         top_dir = Path(path)
         top_dir.mkdir(parents=True, exist_ok=True)
+        directory_manager = DirectoryManager(parent_directory_path=path)
+        data_directory = directory_manager.create_data_directory()
+
         # save the explanation
         if self._explanation:
             save_explanation(self._explanation,
-                             top_dir / ManagerNames.EXPLAINER)
+                             data_directory / ManagerNames.EXPLAINER)
+
         meta = {IS_RUN: self._is_run,
                 IS_ADDED: self._is_added}
-        with open(Path(path) / META_JSON, 'w') as file:
+        with open(data_directory / META_JSON, 'w') as file:
             json.dump(meta, file)
 
     @staticmethod
@@ -324,17 +330,24 @@ class ExplainerManager(BaseManager):
         # create the ExplainerManager without any properties using the __new__
         # function, similar to pickle
         inst = ExplainerManager.__new__(ExplainerManager)
-        top_dir = Path(path)
-        explanation_path = top_dir / ManagerNames.EXPLAINER
-        if explanation_path.exists():
-            explanation = load_explanation(explanation_path)
-            inst.__dict__[EXPLANATION] = explanation
-        inst.__dict__['_' + MODEL] = rai_insights.model
 
-        with open(top_dir / META_JSON, 'r') as meta_file:
+        all_cf_dirs = DirectoryManager.list_sub_directories(path)
+        directory_manager = DirectoryManager(
+            parent_directory_path=path,
+            sub_directory_name=all_cf_dirs[0])
+        data_directory = directory_manager.get_data_directory()
+
+        with open(data_directory / META_JSON, 'r') as meta_file:
             meta = meta_file.read()
         meta = json.loads(meta)
         inst.__dict__['_' + IS_RUN] = meta[IS_RUN]
+
+        explanation_path = data_directory / ManagerNames.EXPLAINER
+        if explanation_path.exists():
+            explanation = load_explanation(explanation_path)
+            inst.__dict__[EXPLANATION] = explanation
+
+        inst.__dict__['_' + MODEL] = rai_insights.model
         inst.__dict__['_' + CLASSES] = rai_insights._classes
         inst.__dict__['_' + CATEGORICAL_FEATURES] = \
             rai_insights.categorical_features

--- a/responsibleai/responsibleai/_tools/shared/base_result.py
+++ b/responsibleai/responsibleai/_tools/shared/base_result.py
@@ -35,17 +35,14 @@ class BaseResult(ABC, Generic[TResult]):
 
         :param path: Path to result directory on disk.
         """
-        result_dir = Path(path)
-        result_dir.mkdir(parents=True, exist_ok=True)
-
         # Save metadata like ID and and version to disk
-        self._save_metadata(result_dir)
+        self._save_metadata(path)
 
         # Save all result attributes to disk
-        save_attributes(self, self._get_attributes(), result_dir)
+        save_attributes(self, self._get_attributes(), path)
 
         # Save dashboard data
-        self._save_dashboard(result_dir)
+        self._save_dashboard(path)
 
     def _save_metadata(self, result_dir: Path):
         """Save result metadata to disk.

--- a/responsibleai/responsibleai/_tools/shared/state_directory_management.py
+++ b/responsibleai/responsibleai/_tools/shared/state_directory_management.py
@@ -1,0 +1,124 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+"""Directory management of state of ResponsibleAI insights."""
+
+import os
+import uuid
+from pathlib import Path
+
+
+class DirectoryManager:
+
+    CONFIGURATION = 'configuration'
+    DATA = 'data'
+    EXPLAINER = 'explainer'
+
+    def __init__(self, parent_directory_path, sub_directory_name=None):
+        """Directory manager for managing the configuration,
+           dashboard data and explainers need to recompose the state
+           in the various managers.
+
+        :param parent_directory_path: Directory path of where the state data
+                                      directory will be stored.
+        :type parent_directory_path: Path
+        :param sub_directory_name: The name where the state needs to be stored
+                                   or the directory where the state can be
+                                   found.
+        :type sub_directory_name: str
+        """
+        self.parent_directory_path = parent_directory_path
+
+        if sub_directory_name is None:
+            self.sub_directory_name = str(uuid.uuid4())
+        else:
+            self.sub_directory_name = sub_directory_name
+
+        parent_directory = Path(self.parent_directory_path)
+        if not parent_directory.exists():
+            parent_directory.mkdir(parents=True, exist_ok=True)
+
+        sub_directory = (Path(self.parent_directory_path) /
+                         self.sub_directory_name)
+        if not sub_directory.exists():
+            sub_directory.mkdir(parents=True, exist_ok=True)
+
+    def create_config_directory(self):
+        """Create the configuration directory and return its path.
+
+        :returns: Path to the configuration directory.
+        """
+        config_directory = (Path(self.parent_directory_path) /
+                            self.sub_directory_name /
+                            DirectoryManager.CONFIGURATION)
+        if not config_directory.exists():
+            config_directory.mkdir(parents=True, exist_ok=True)
+
+        return config_directory
+
+    def create_data_directory(self):
+        """Create the dashboard data directory and return its path.
+
+        :returns: Path to the dashboard data directory.
+        """
+        data_directory = (Path(self.parent_directory_path) /
+                          self.sub_directory_name /
+                          DirectoryManager.DATA)
+        if not data_directory.exists():
+            data_directory.mkdir(parents=True, exist_ok=True)
+
+        return data_directory
+
+    def create_explainer_directory(self):
+        """Create the explainer directory and return its path.
+
+        :returns: Path to the explainer directory.
+        """
+        explainer_directory = (Path(self.parent_directory_path) /
+                               self.sub_directory_name /
+                               DirectoryManager.EXPLAINER)
+        if not explainer_directory.exists():
+            explainer_directory.mkdir(parents=True, exist_ok=True)
+
+        return explainer_directory
+
+    def get_config_directory(self):
+        """Return the path of the configuration directory.
+
+        :returns: Path to the configuration directory.
+        :rtype: Path
+        """
+        return (Path(self.parent_directory_path) /
+                self.sub_directory_name /
+                DirectoryManager.CONFIGURATION)
+
+    def get_data_directory(self):
+        """Return the path of the dashboard data directory.
+
+        :returns: Path to the dashboard data directory.
+        :rtype: Path
+        """
+        return (Path(self.parent_directory_path) /
+                self.sub_directory_name /
+                DirectoryManager.DATA)
+
+    def get_explainer_directory(self):
+        """Return the path of the explainer directory.
+
+        :returns: Path to the explainer directory.
+        :rtype: Path
+        """
+        return (Path(self.parent_directory_path) /
+                self.sub_directory_name /
+                DirectoryManager.EXPLAINER)
+
+    @staticmethod
+    def list_sub_directories(path):
+        """List all the directories give a path and return.
+
+        :param path: Path to look into to list all directories.
+        :type path: Path
+
+        :returns: List of all directories found in this path.
+        :rtype: List[str]
+        """
+        return os.listdir(Path(path))

--- a/responsibleai/responsibleai/exceptions.py
+++ b/responsibleai/responsibleai/exceptions.py
@@ -19,3 +19,13 @@ class UserConfigValidationException(Exception):
     :type exception_message: str
     """
     _error_code = 'Invalid config'
+
+
+class ConfigAndResultMismatchException(Exception):
+    """An exception indicating that number of configuration and
+       results are different.
+
+    :param exception_message: A message describing the error.
+    :type exception_message: str
+    """
+    _error_code = 'Config and result mismatch'

--- a/responsibleai/tests/test_model_analysis.py
+++ b/responsibleai/tests/test_model_analysis.py
@@ -7,11 +7,14 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import numpy as np
+import os
 import pandas as pd
 import pytest
 
 from responsibleai import ModelAnalysis, ModelTask
 from responsibleai._internal.constants import ManagerNames
+from responsibleai._tools.shared.state_directory_management import \
+    DirectoryManager
 
 from .causal_manager_validator import validate_causal
 from .common_utils import (create_adult_income_dataset,
@@ -231,8 +234,14 @@ def run_model_analysis(model, train_data, test_data, target_column,
 
     with TemporaryDirectory() as tempdir:
         path = Path(tempdir) / 'rai_test_path'
+
         # save the model_analysis
         model_analysis.save(path)
+
+        # Validate the directory structure of the state saved
+        # by the managers.
+        validate_state_directory(path, manager_type)
+
         # load the model_analysis
         model_analysis = ModelAnalysis.load(path)
 
@@ -250,6 +259,36 @@ def run_model_analysis(model, train_data, test_data, target_column,
             # validate adding new explainer config after deserialization works
             setup_explainer(model_analysis)
             validate_explainer(model_analysis, train_data, test_data, classes)
+
+
+def validate_state_directory(path, manager_type):
+    all_dirs = os.listdir(path)
+    assert manager_type in all_dirs
+    all_component_paths = os.listdir(path / manager_type)
+    for component_path in all_component_paths:
+        # TODO: Add code to check if the component_path is GUID
+        dm = DirectoryManager(path / manager_type, component_path)
+
+        config_path = dm.get_config_directory()
+        data_path = dm.get_data_directory()
+        explainer_path = dm.get_explainer_directory()
+
+        if manager_type == ManagerNames.EXPLAINER:
+            assert not config_path.exists()
+            assert data_path.exists()
+            assert not explainer_path.exists()
+        elif manager_type == ManagerNames.COUNTERFACTUAL:
+            assert config_path.exists()
+            assert data_path.exists()
+            assert not explainer_path.exists()
+        elif manager_type == ManagerNames.ERROR_ANALYSIS:
+            assert config_path.exists()
+            assert data_path.exists()
+            assert not explainer_path.exists()
+        elif manager_type == ManagerNames.CAUSAL:
+            assert not config_path.exists()
+            assert data_path.exists()
+            assert not explainer_path.exists()
 
 
 def validate_model_analysis(

--- a/responsibleai/tests/test_state_directory_management.py
+++ b/responsibleai/tests/test_state_directory_management.py
@@ -1,0 +1,84 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+from pathlib import Path
+
+from responsibleai._tools.shared.state_directory_management import \
+    DirectoryManager
+
+
+class TestStateDirectoryManagement:
+
+    def _verify_directory_manager_operations(self, directory_manager):
+
+        # Test the create APIs
+        config_directory_path = directory_manager.create_config_directory()
+        assert isinstance(config_directory_path, Path)
+        assert config_directory_path.exists()
+        assert DirectoryManager.CONFIGURATION in str(config_directory_path)
+
+        data_directory_path = directory_manager.create_data_directory()
+        assert isinstance(data_directory_path, Path)
+        assert data_directory_path.exists()
+        assert DirectoryManager.DATA in str(data_directory_path)
+
+        explainer_directory_path = \
+            directory_manager.create_explainer_directory()
+        assert isinstance(explainer_directory_path, Path)
+        assert explainer_directory_path.exists()
+        assert DirectoryManager.EXPLAINER in str(explainer_directory_path)
+
+        # Test the get APIs
+        config_directory_path = directory_manager.get_config_directory()
+        assert isinstance(config_directory_path, Path)
+        assert config_directory_path.exists()
+        assert DirectoryManager.CONFIGURATION in str(config_directory_path)
+
+        data_directory_path = directory_manager.get_data_directory()
+        assert isinstance(data_directory_path, Path)
+        assert data_directory_path.exists()
+        assert DirectoryManager.DATA in str(data_directory_path)
+
+        explainer_directory_path = directory_manager.get_explainer_directory()
+        assert isinstance(explainer_directory_path, Path)
+        assert explainer_directory_path.exists()
+        assert DirectoryManager.EXPLAINER in str(explainer_directory_path)
+
+    def test_directory_manager(self, tmpdir):
+        parent_directory = tmpdir.mkdir('parent_directory')
+        dm_one = DirectoryManager(
+            parent_directory_path=parent_directory,
+            sub_directory_name='known')
+
+        assert dm_one.parent_directory_path.exists()
+        assert dm_one.sub_directory_name == 'known'
+        assert (dm_one.parent_directory_path /
+                dm_one.sub_directory_name).exists()
+
+        self._verify_directory_manager_operations(dm_one)
+
+        assert isinstance(
+            DirectoryManager.list_sub_directories(parent_directory),
+            list)
+        assert len(
+            DirectoryManager.list_sub_directories(parent_directory)) == 1
+        assert 'known' in\
+            DirectoryManager.list_sub_directories(parent_directory)
+
+        dm_two = DirectoryManager(
+            parent_directory_path=parent_directory)
+
+        assert dm_two.parent_directory_path.exists()
+        assert dm_two.sub_directory_name is not None
+        assert (dm_two.parent_directory_path /
+                dm_two.sub_directory_name).exists()
+
+        self._verify_directory_manager_operations(dm_two)
+
+        assert isinstance(
+            DirectoryManager.list_sub_directories(parent_directory),
+            list)
+        assert len(
+            DirectoryManager.list_sub_directories(parent_directory)) == 2
+        assert dm_two.sub_directory_name in\
+            DirectoryManager.list_sub_directories(parent_directory)


### PR DESCRIPTION
This PR has the following changes:-

- Move state of counterfactual, explainer, causal and erroranalysis manager to directory based state management as below.
- Add directory based state manager
- Add the unit tests for directory based state manager
- Add tests for checking the directory based storage paths for each manager state.

model_analysis_state/
|----explanations/
|----error_analysis/
|----causal/
|----counterfactual/
|--------guid1/
|------------config/
|----------------config.json
|------------data/
|----------------f1.json
|----------------f2.json
|----------------f3.json
|------------explainer/
|----------------model1.pkl
|----------------model2.pkl
|--------guid2/
|------------config/
|----------------config.json
|------------data/
|----------------f1.json
|----------------f2.json
|----------------schema.json
|------------explainer/
|----------------model1.pkl
|----------------conda_env.yml
|--------guid3/
|----model.pkl
|----train.json
|----test.json