### PR TITLE
rename ModelAnalysisDashboard to ResponsibleAIDashboard

### DIFF
--- a/apps/widget/src/app/App.tsx
+++ b/apps/widget/src/app/App.tsx
@@ -20,7 +20,7 @@ export class App extends React.Component {
         return <Interpret dashboardType={config.dashboardType} />;
       case "ErrorAnalysis":
         return <ErrorAnalysis />;
-      case "ModelAssessment":
+      case "ResponsibleAI":
         return <ModelAssessment />;
       default:
         return "Not Found";

--- a/apps/widget/src/app/config.ts
+++ b/apps/widget/src/app/config.ts
@@ -7,7 +7,7 @@ export interface IAppConfig {
     | "Interpret"
     | "ErrorAnalysis"
     | "ModelPerformance"
-    | "ModelAssessment";
+    | "ResponsibleAI";
   id: string;
   baseUrl: string;
   withCredentials: boolean;

--- a/raiwidgets/raiwidgets/__init__.py
+++ b/raiwidgets/raiwidgets/__init__.py
@@ -9,9 +9,10 @@ from .explanation_dashboard import ExplanationDashboard
 from .fairness_dashboard import FairnessDashboard
 from .model_analysis_dashboard import ModelAnalysisDashboard
 from .model_performance_dashboard import ModelPerformanceDashboard
+from .responsibleai_dashboard import ResponsibleAIDashboard
 
 __version__ = version
 
 __all__ = ['FairnessDashboard', 'ExplanationDashboard',
            'ErrorAnalysisDashboard', 'ModelPerformanceDashboard',
-           'ModelAnalysisDashboard']
+           'ModelAnalysisDashboard', 'ResponsibleAIDashboard']

--- a/raiwidgets/raiwidgets/model_analysis_dashboard.py
+++ b/raiwidgets/raiwidgets/model_analysis_dashboard.py
@@ -3,16 +3,17 @@
 
 """Defines the Model Analysis Dashboard class."""
 
-from flask import jsonify, request
-
 from responsibleai import RAIInsights
 
-from .dashboard import Dashboard
-from .model_analysis_dashboard_input import ModelAnalysisDashboardInput
+from .responsibleai_dashboard import ResponsibleAIDashboard
+import warnings
 
 
-class ModelAnalysisDashboard(Dashboard):
+class ModelAnalysisDashboard(object):
     """The dashboard class, wraps the dashboard component.
+
+    Note: this class is now deprecated, please use the
+    ResponsibleAIDashboard instead.
 
     :param analysis: An object that represents an model analysis.
     :type analysis: RAIInsights
@@ -26,40 +27,8 @@ class ModelAnalysisDashboard(Dashboard):
 
     def __init__(self, analysis: RAIInsights,
                  public_ip=None, port=None, locale=None):
-        self.input = ModelAnalysisDashboardInput(analysis)
-
-        super(ModelAnalysisDashboard, self).__init__(
-            dashboard_type="ModelAssessment",
-            model_data=self.input.dashboard_input,
-            public_ip=public_ip,
-            port=port,
-            locale=locale,
-            no_inline_dashboard=True)
-
-        def predict():
-            data = request.get_json(force=True)
-            return jsonify(self.input.on_predict(data))
-        self.add_url_rule(predict, '/predict', methods=["POST"])
-
-        def tree():
-            data = request.get_json(force=True)
-            return jsonify(self.input.debug_ml(data))
-
-        self.add_url_rule(tree, '/tree', methods=["POST"])
-
-        def matrix():
-            data = request.get_json(force=True)
-            return jsonify(self.input.matrix(data))
-
-        self.add_url_rule(matrix, '/matrix', methods=["POST"])
-
-        def causal_whatif():
-            data = request.get_json(force=True)
-            return jsonify(self.input.causal_whatif(data))
-
-        self.add_url_rule(causal_whatif, '/causal_whatif', methods=["POST"])
-
-        def importances():
-            return jsonify(self.input.importances())
-
-        self.add_url_rule(importances, '/importances', methods=["POST"])
+        warnings.warn("ModelAnalysisDashboard in raiwidgets package is "
+                      "deprecated."
+                      "Please use ResponsibleAIDashboard instead.")
+        rai = ResponsibleAIDashboard(analysis, public_ip, port, locale)
+        self.input = rai.input

--- a/raiwidgets/raiwidgets/responsibleai_dashboard.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard.py
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+"""Defines the Model Analysis Dashboard class."""
+
+from flask import jsonify, request
+
+from responsibleai import RAIInsights
+
+from .dashboard import Dashboard
+from .responsibleai_dashboard_input import ResponsibleAIDashboardInput
+
+
+class ResponsibleAIDashboard(Dashboard):
+    """The dashboard class, wraps the dashboard component.
+
+    :param analysis: An object that represents an RAIInsights.
+    :type analysis: RAIInsights
+    :param public_ip: Optional. If running on a remote vm,
+        the external public ip address of the VM.
+    :type public_ip: str
+    :param port: The port to use on locally hosted service.
+    :type port: int
+
+    """
+
+    def __init__(self, analysis: RAIInsights,
+                 public_ip=None, port=None, locale=None):
+        self.input = ResponsibleAIDashboardInput(analysis)
+
+        super(ResponsibleAIDashboard, self).__init__(
+            dashboard_type="ResponsibleAI",
+            model_data=self.input.dashboard_input,
+            public_ip=public_ip,
+            port=port,
+            locale=locale,
+            no_inline_dashboard=True)
+
+        def predict():
+            data = request.get_json(force=True)
+            return jsonify(self.input.on_predict(data))
+        self.add_url_rule(predict, '/predict', methods=["POST"])
+
+        def tree():
+            data = request.get_json(force=True)
+            return jsonify(self.input.debug_ml(data))
+
+        self.add_url_rule(tree, '/tree', methods=["POST"])
+
+        def matrix():
+            data = request.get_json(force=True)
+            return jsonify(self.input.matrix(data))
+
+        self.add_url_rule(matrix, '/matrix', methods=["POST"])
+
+        def causal_whatif():
+            data = request.get_json(force=True)
+            return jsonify(self.input.causal_whatif(data))
+
+        self.add_url_rule(causal_whatif, '/causal_whatif', methods=["POST"])
+
+        def importances():
+            return jsonify(self.input.importances())
+
+        self.add_url_rule(importances, '/importances', methods=["POST"])

--- a/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
+++ b/raiwidgets/raiwidgets/responsibleai_dashboard_input.py
@@ -15,7 +15,7 @@ from .interfaces import WidgetRequestResponseConstants
 EXP_VIZ_ERR_MSG = ErrorMessages.EXP_VIZ_ERR_MSG
 
 
-class ModelAnalysisDashboardInput:
+class ResponsibleAIDashboardInput:
     def __init__(
             self,
             analysis: RAIInsights):

--- a/raiwidgets/tests/test_responsibleai_dashboard.py
+++ b/raiwidgets/tests/test_responsibleai_dashboard.py
@@ -1,0 +1,60 @@
+# Copyright (c) Microsoft Corporation
+# Licensed under the MIT License.
+
+import shap
+import sklearn
+from sklearn.model_selection import train_test_split
+
+from raiwidgets import ResponsibleAIDashboard
+from responsibleai import RAIInsights
+from responsibleai._interfaces import (CausalData, CounterfactualData, Dataset,
+                                       ErrorAnalysisData, ModelExplanationData)
+
+
+class TestResponsibleAIDashboard:
+    def test_responsibleai_adult(self):
+        X, y = shap.datasets.adult()
+        y = [1 if r else 0 for r in y]
+
+        X, y = sklearn.utils.resample(
+            X, y, n_samples=1000, random_state=7, stratify=y)
+
+        X_train, X_test, y_train, y_test = train_test_split(
+            X, y, test_size=0.2, random_state=7, stratify=y)
+
+        knn = sklearn.neighbors.KNeighborsClassifier()
+        knn.fit(X_train, y_train)
+
+        X['Income'] = y
+        X_test['Income'] = y_test
+
+        ri = RAIInsights(knn, X, X_test, 'Income', 'classification',
+                         categorical_features=['Workclass', 'Education-Num',
+                                               'Marital Status',
+                                               'Occupation', 'Relationship',
+                                               'Race',
+                                               'Sex', 'Country'])
+        ri.explainer.add()
+        ri.counterfactual.add(10, desired_class='opposite')
+        ri.error_analysis.add()
+        ri.causal.add(treatment_features=['Hours per week', 'Occupation'],
+                      heterogeneity_features=None,
+                      upper_bound_on_cat_expansion=42,
+                      skip_cat_limit_checks=True)
+        ri.compute()
+
+        widget = ResponsibleAIDashboard(ri)
+        assert isinstance(widget.input.dashboard_input.dataset,
+                          Dataset)
+        assert isinstance(
+            widget.input.dashboard_input.modelExplanationData[0],
+            ModelExplanationData)
+        assert isinstance(
+            widget.input.dashboard_input.errorAnalysisData[0],
+            ErrorAnalysisData)
+        assert isinstance(
+            widget.input.dashboard_input.causalAnalysisData[0],
+            CausalData)
+        assert isinstance(
+            widget.input.dashboard_input.counterfactualData[0],
+            CounterfactualData)

--- a/raiwidgets/tests/test_responsibleai_dashboard_input.py
+++ b/raiwidgets/tests/test_responsibleai_dashboard_input.py
@@ -6,12 +6,12 @@ import shap
 import sklearn
 from sklearn.model_selection import train_test_split
 
-from raiwidgets.model_analysis_dashboard_input import \
-    ModelAnalysisDashboardInput
-from responsibleai import ModelAnalysis
+from raiwidgets.responsibleai_dashboard_input import \
+    ResponsibleAIDashboardInput
+from responsibleai import RAIInsights
 
 
-class TestModelAnalysisDashboardInput:
+class TestResponsibleAIDashboardInput:
     def test_model_analysis_adult(self):
         X, y = shap.datasets.adult()
         y = [1 if r else 0 for r in y]
@@ -28,12 +28,12 @@ class TestModelAnalysisDashboardInput:
         X['Income'] = y
         X_test['Income'] = y_test
 
-        ma = ModelAnalysis(knn, X, X_test, 'Income', 'classification',
-                           categorical_features=['Workclass', 'Education-Num',
-                                                 'Marital Status',
-                                                 'Occupation', 'Relationship',
-                                                 'Race',
-                                                 'Sex', 'Country'])
+        ma = RAIInsights(knn, X, X_test, 'Income', 'classification',
+                         categorical_features=['Workclass', 'Education-Num',
+                                               'Marital Status',
+                                               'Occupation', 'Relationship',
+                                               'Race',
+                                               'Sex', 'Country'])
         # ma.explainer.add()
         # ma.counterfactual.add(10, desired_class='opposite')
         ma.error_analysis.add()
@@ -43,7 +43,7 @@ class TestModelAnalysisDashboardInput:
         #               skip_cat_limit_checks=True)
         ma.compute()
 
-        dashboard_input = ModelAnalysisDashboardInput(ma)
+        dashboard_input = ResponsibleAIDashboardInput(ma)
         with mock.patch.object(knn, "predict_proba") as predict_mock:
             test_pred_data = X_test.head(1).drop("Income", axis=1).values
             dashboard_input.on_predict(

--- a/scripts/e2e-widget.js
+++ b/scripts/e2e-widget.js
@@ -10,7 +10,7 @@ const baseDir = path.join(
 );
 const filePrefix = "responsibleaitoolbox";
 
-const hostReg = /^ModelAssessment started at (http:\/\/localhost:\d+)$/m;
+const hostReg = /^ResponsibleAI started at (http:\/\/localhost:\d+)$/m;
 const timeout = 3600;
 
 /**


### PR DESCRIPTION
Part two of OSS renames.
Rename the ModelAnalysisDashboard class to ResponsibleAIDashboard in the raiwidgets package.
The next step will be to release the OSS packages and then update the jupyter notebooks to use the new classes in a follow-up PR.