### PR TITLE
when classes are not passed, sort them automatically

### DIFF
--- a/responsibleai/responsibleai/rai_insights/rai_insights.py
+++ b/responsibleai/responsibleai/rai_insights/rai_insights.py
@@ -153,7 +153,10 @@ class RAIInsights(object):
     def _get_classes(task_type, train, target_column, classes):
         if task_type == ModelTask.CLASSIFICATION:
             if classes is None:
-                return train[target_column].unique()
+                classes = train[target_column].unique()
+                # sort the classes after calling unique in numeric case
+                classes.sort()
+                return classes
             else:
                 return classes
         else:

--- a/responsibleai/tests/test_model_analysis.py
+++ b/responsibleai/tests/test_model_analysis.py
@@ -306,5 +306,7 @@ def validate_model_analysis(
     assert model_analysis.task_type == task_type
     assert model_analysis.categorical_features == categorical_features
     if task_type == ModelTask.CLASSIFICATION:
+        classes = train_data[target_column].unique()
+        classes.sort()
         np.testing.assert_array_equal(model_analysis.rai_insights._classes,
-                                      train_data[target_column].unique())
+                                      classes)

--- a/responsibleai/tests/test_rai_insights.py
+++ b/responsibleai/tests/test_rai_insights.py
@@ -303,5 +303,7 @@ def validate_rai_insights(
     assert rai_insights.task_type == task_type
     assert rai_insights.categorical_features == categorical_features
     if task_type == ModelTask.CLASSIFICATION:
+        classes = train_data[target_column].unique()
+        classes.sort()
         np.testing.assert_array_equal(rai_insights._classes,
-                                      train_data[target_column].unique())
+                                      classes)

--- a/responsibleai/tests/test_rai_insights_validations.py
+++ b/responsibleai/tests/test_rai_insights_validations.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+import numpy as np
 
 from responsibleai.exceptions import UserConfigValidationException
 from responsibleai import RAIInsights
@@ -261,7 +262,7 @@ class TestRAIInsightsValidations:
         assert 'The features in train and test data do not match' in \
             str(ucve.value)
 
-    def test_classes(self):
+    def test_classes_exceptions(self):
         X_train, X_test, y_train, y_test, _, _ = \
             create_cancer_data()
         model = create_lightgbm_classifier(X_train, y_train)
@@ -311,6 +312,24 @@ class TestRAIInsightsValidations:
 
         assert 'The train labels and distinct values in target ' + \
             '(test data) do not match' in str(ucve.value)
+
+    def test_classes_passes(self):
+        X_train, X_test, y_train, y_test, _, _ = \
+            create_cancer_data()
+        model = create_lightgbm_classifier(X_train, y_train)
+
+        X_train['target'] = y_train
+        X_test['target'] = y_test
+
+        rai = RAIInsights(
+            model=model,
+            train=X_train,
+            test=X_test,
+            target_column='target',
+            task_type='classification')
+        # validate classes are always sorted
+        classes = rai._classes
+        assert np.all(classes[:-1] <= classes[1:])
 
 
 class TestCausalUserConfigValidations:


### PR DESCRIPTION
When classes are not passed to RAIInsights, sort them automatically.
Currently, if the user has classes like "0", "1", they may get arranged in any order after calling unique(), hence it is common for classes to be the array [1,0].  This can give results in ResponsibleAIDashboard which look difficult to interpret, since the probabilities for negative class now correspond to positive 1.0 probability. 